### PR TITLE
[NO ISSUE] fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ partial.test("goodbye"); // false - cannot match
 ```javascript
 import "regex-partial-match/extend";
 
-const partial = /hello world/.createPartialMatchRegexRegex();
+const partial = /hello world/.toPartialMatchRegex();
 
 partial.test("hel"); // true
 ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fixed typo in main `README.md` describing prototype extension
+
+## [0.1.4] - 2025-12-07
+
+### Fixed
+
 - move to a fine-grained PAT that should be able to write to the repo for `CHANGELOG.md` updates after release
 
 ## [0.1.3] - 2025-12-07

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regex-partial-match",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A regular expression transform for partial matching",
   "engines": {
     "node": ">=23"


### PR DESCRIPTION
I spotted a copy pasta error in the `README.md` regarding the nature of `"regex-partial-match/extend"` - this fixes that