### PR TITLE
[NO ISSUE] update backreference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,17 +103,9 @@ The library is compiled to **ES5** for broad compatibility with older browsers a
 
 ### Backreferences
 
-**Backreferences with variable-length captures cannot be partially matched** due to ambiguity in how the pattern should be matched. While simple fixed-length backreferences like `/(abc)\1/` could theoretically be transformed (if accepting that the group indexes would be polluted, compared to the original), to become `/(?:(a)|$)(?:(b)|$)(?:(c)|$)(?:\1|$)(?:\2|$)(?:\3|$)/` variable-length patterns break down.
+**Backreferences cannot be partially matched because they are atomic.** A backreference like `\1` must match the complete captured text or fail entirely, and cannot be split into individual characters for partial matching like regular atoms can.
 
-For example, with `/(\w+) \1/` (matches "hello hello"):
-
-- A naive transformation `/(?:(\w+)|$)(?:( )|$)(?:\1|$)/` creates ambiguity
-- For input "hello h", the regex can match in multiple ways:
-  - Capture group 1 as "hello", skip the space with `$`, skip `\1` with `$` ✓
-  - Capture group 1 as "h", skip the space with `$`, match `\1` as "h" ✓ (at position 6)
-- The engine chooses the second interpretation, matching just "h" instead of recognizing "hello h" as a partial match
-
-The core issue: **the regex engine cannot determine which part of the input should be captured vs. which part should match the backreference** when dealing with variable-length patterns and incomplete input. Fixed-length patterns like `/(abc)\1/` avoid this ambiguity since each character position has a clear role.
+Fixed-length patterns like `/(abc)\1/` could theoretically become `/(?:(a)|$)(?:(b)|$)(?:(c)|$)(?:\1|$)(?:\2|$)(?:\3|$)/` (accepting polluted capture indexes as a side-effect), but this doesn't work for variable-length captures.
 
 ### Surrogate Pair Matching
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Simplified documentation on Backreference caveats
+
+## [0.1.6]
+
 ### Fixed
 
 - Fixed typo in `CONTRIBUTING.md` with old nomenclature for `createPartialMatchRegex`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regex-partial-match",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A regular expression transform for partial matching",
   "engines": {
     "node": ">=23"


### PR DESCRIPTION
The hello world example talked of "skipping the space" which didn't make sense.

I think the fundamental issue of back-references being atomic is probably enough to explain the shortcoming.