### PR TITLE
[23] move to node-v6 and corresponding change to devEngines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -38,10 +37,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: "npm"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,11 +18,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           registry-url: "https://registry.npmjs.org"
-          cache: "npm"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
-          cache: "npm"
 
       - name: Install dependencies
         run: npm ci

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated [`actions/setup-node`](https://github.com/actions/setup-node) to version 6
+
+### Fixed
+
+- Moved `package.json` [engines](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#engines) to [devEngines](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#devengines), since Node 23+ only needed for RegExp features in tests, the library itself is compatible with all versions of Node
+
 ## [0.1.11] - 2025-12-19
+
 ### Fixed
 
 - Added link from supported features to sticky flag caveat in `README.md`

--- a/package.json
+++ b/package.json
@@ -2,8 +2,14 @@
   "name": "regex-partial-match",
   "version": "0.1.11",
   "description": "A regular expression transform for partial matching",
-  "engines": {
-    "node": ">=23"
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">=23"
+    },
+    "packageManager": {
+      "name": "npm"
+    }
   },
   "keywords": [
     "regexp",


### PR DESCRIPTION
# Issue

resolves #23 

## Details

Move to `devEngines` from `engines` in `package.json`, to better express the reality that the library fully supports any Node version.

## Semantic Version Impact

_Select ONE checkbox to indicate the semver impact of this change. Learn more at https://semver.org/_

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## Scout rule

- Move [`actions/setup-node`](https://github.com/actions/setup-node) to latest version (v6)
  - remove the `cache` entry in workflows, this will be read automatically from the `devEngines` setting

## CheckList

- [x] PR starts with [_ISSUE_ID_]
- [x] I have added an entry to the `[Unreleased]` section in `docs/CHANGELOG.md`
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
