### PR TITLE
[29] add browser support note for `unicodeSets`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
           echo "Checking PR description for semver selection..."
 
           # Count how many semver checkboxes are selected
-          SELECTED_COUNT=$(echo "$PR_BODY" | grep -cE "\[x\] \*\*(MAJOR|MINOR|PATCH)\*\*" || true)
+          SELECTED_COUNT=$(echo "$PR_BODY" | grep -cE "\[[xX]\] \*\*(MAJOR|MINOR|PATCH)\*\*" || true)
 
           if [ "$SELECTED_COUNT" -eq 0 ]; then
             echo "❌ Error: No semver checkbox selected in PR description"
@@ -136,7 +136,7 @@ jobs:
             echo "Multiple selections create ambiguous version intent."
             echo ""
             echo "Current selections:"
-            echo "$PR_BODY" | grep -E "\[x\] \*\*(MAJOR|MINOR|PATCH)\*\*"
+            echo "$PR_BODY" | grep -E "\[[xX]\] \*\*(MAJOR|MINOR|PATCH)\*\*"
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ Such combinations have not been tested.
 ## Supported Features
 
 - 🔤 [Literal characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Literal_character)
-- 📋 [Character classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class) (`[abc]`, `[^abc]`, `[a-z]`)
 - 🔣 [Character escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape) (`\n`, `\t`, `\x61`, `\u0061`, `\u{1F600}`)
+- 🧩 [Character class escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class_escape): `/\w+/`, `/\d{3}/`
 - 🌐 [Unicode character class escape](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape) (`\p{Letter}`, `\P{Letter}`)
+- 📋 [Character classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class) (`[abc]`, `[^abc]`, `[a-z]`)
 - 🧮 [Unicode sets (`v` flag)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) (`/[\p{Lowercase}&&\p{Script=Greek}]/v`)
 - 🔢 [Quantifiers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Quantifier) (`*`, `+`, `?`, `{n}`, `{n,}`, `{n,m}`)
 - 🔀 [Disjunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction) (`a|b`)
@@ -99,6 +100,7 @@ The library is compiled to **ES5** for broad compatibility with older browsers a
 - [**Named capturing groups**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group) (`(?<name>...)`) - ES2018+
 - [**`s` (dotAll) flag**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll) - ES2018+
 - [**`d` (hasIndices) flag**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices) - ES2022+
+- [**`v` (unicodeSets) flag**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) - ES2024+
 
 ## Caveats
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add note to `README.md` that `unicodeSet` / `v` flag requires ES2024+ for browser support
+
+### Fixed
+
+- Allow semver selection in ci workflow to support case-insensitive checkboxes, since that's what's valid in Github Flavoured Markdown
+- Add missing "Character Class Escapes" to supported features in `README.md`
+- Fixup some test cases for unicode sets
+  - character class wrapping escapes, since this differentiates from `u` flag
+  - missing tests for unions
+  - complement syntax
+
 ## [0.2.0] - 2025-12-24
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Allow semver selection in ci workflow to support case-insensitive checkboxes, since that's what's valid in Github Flavoured Markdown
+- Allow semver selection in ci workflow to support case-insensitive checkboxes, since that's what's valid in GitHub Flavoured Markdown
 - Add missing "Character Class Escapes" to supported features in `README.md`
 - Fixup some test cases for unicode sets
   - character class wrapping escapes, since this differentiates from `u` flag

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add note to `README.md` that `unicodeSet` / `v` flag requires ES2024+ for browser support
+- Add note to `README.md` that `unicodeSets` / `v` flag requires ES2024+ for browser support
 
 ### Fixed
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -508,12 +508,12 @@ describe("regexp-partial-match", () => {
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets
   describe("unicode sets (extending features)", () => {
     it("should support partial matching of unicode set expressions", () => {
-      const input = /[\p{Script=Hiragana}]+suffix/v;
+      const input = /[\p{Alphabetic}]+suffix/v;
       const partial = createPartialMatchRegex(input);
       expect(partial).toMatchPartially({
-        characters: ["あ", "い", "う", ..."suffix".split("")]
+        characters: ["a", "b", "c", ..."suffix".split("")]
       });
-      expect(partial.exec("A")).toNotMatch();
+      expect(partial.exec("あ")).toNotMatch();
     });
 
     it("should support partial matching of grapheme clusters / string properties (with caveat that individual code points do not match independently)", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -511,9 +511,9 @@ describe("regexp-partial-match", () => {
       const input = /[\p{Alphabetic}]+suffix/v;
       const partial = createPartialMatchRegex(input);
       expect(partial).toMatchPartially({
-        characters: ["a", "b", "c", ..."suffix".split("")]
+        characters: ["a", "あ", "c", ..."suffix".split("")]
       });
-      expect(partial.exec("あ")).toNotMatch();
+      expect(partial.exec("1")).toNotMatch();
     });
 
     it("should support partial matching of grapheme clusters / string properties (with caveat that individual code points do not match independently)", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -588,7 +588,7 @@ describe("regexp-partial-match", () => {
       const input = /[[\p{Script_Extensions=Greek}][xyz]]+suffix/v;
       const partial = createPartialMatchRegex(input);
       expect(partial).toMatchPartially({
-        characters: ["α", "β", "δ", "ε", "x", "y", "z", ..."suffix".split("")]
+        characters: ["α", "γ", "δ", "ε", "x", "y", "z", ..."suffix".split("")]
       });
     });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -508,7 +508,7 @@ describe("regexp-partial-match", () => {
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets
   describe("unicode sets (extending features)", () => {
     it("should support partial matching of unicode set expressions", () => {
-      const input = /\p{Script=Hiragana}+suffix/v;
+      const input = /[\p{Script=Hiragana}]+suffix/v;
       const partial = createPartialMatchRegex(input);
       expect(partial).toMatchPartially({
         characters: ["あ", "い", "う", ..."suffix".split("")]
@@ -517,7 +517,7 @@ describe("regexp-partial-match", () => {
     });
 
     it("should support partial matching of grapheme clusters / string properties (with caveat that individual code points do not match independently)", () => {
-      const input = /\p{RGI_Emoji_Flag_Sequence}suffix/v;
+      const input = /[\p{RGI_Emoji_Flag_Sequence}]suffix/v;
       const partial = createPartialMatchRegex(input);
       expect(partial).toMatchPartially({
         characters: ["🇺🇳", ..."suffix".split("")] // "🇺🇳".length === 4
@@ -525,8 +525,17 @@ describe("regexp-partial-match", () => {
       expect(partial.exec("A")).toNotMatch();
     });
 
+    it("should support partial matching of unicode set expressions using key/value syntax", () => {
+      const input = /[\p{Script=Hiragana}]+suffix/v;
+      const partial = createPartialMatchRegex(input);
+      expect(partial).toMatchPartially({
+        characters: ["あ", "い", "う", ..."suffix".split("")]
+      });
+      expect(partial.exec("A")).toNotMatch();
+    });
+
     it("should support partial matching of negated unicode set expressions", () => {
-      const input = /\P{Script=Hiragana}+suffix/v;
+      const input = /[\P{Script=Hiragana}]+suffix/v;
       const partial = createPartialMatchRegex(input);
       expect(partial).toMatchPartially({
         characters: ["A", "b", "1", "_", "å", "ä", "ö", ..."suffix".split("")]
@@ -534,13 +543,13 @@ describe("regexp-partial-match", () => {
       expect(partial.exec("あ")).toNotMatch();
     });
 
-    it("should support partial matching of subtraction in unicode set character class expressions", () => {
-      const input = /[\p{Script_Extensions=Greek}--π]+suffix/v;
+    it("should support partial matching of negated unicode set expressions using complement syntax", () => {
+      const input = /[^\p{Script=Hiragana}]+suffix/v;
       const partial = createPartialMatchRegex(input);
       expect(partial).toMatchPartially({
-        characters: ["α", "β", "γ", "δ", "ε", ..."suffix".split("")]
+        characters: ["A", "b", "1", "_", "å", "ä", "ö", ..."suffix".split("")]
       });
-      expect(partial.exec("π")).toNotMatch();
+      expect(partial.exec("あ")).toNotMatch();
     });
 
     it("should support empty sets as a non-match in unicode set character class expressions", () => {
@@ -558,11 +567,28 @@ describe("regexp-partial-match", () => {
       });
     });
 
+    it("should support partial matching of subtraction in unicode set character class expressions", () => {
+      const input = /[\p{Script_Extensions=Greek}--π]+suffix/v;
+      const partial = createPartialMatchRegex(input);
+      expect(partial).toMatchPartially({
+        characters: ["α", "β", "γ", "δ", "ε", ..."suffix".split("")]
+      });
+      expect(partial.exec("π")).toNotMatch();
+    });
+
     it("should support partial matching of intersection in unicode set character class expressions", () => {
       const input = /[\p{Script_Extensions=Greek}&&[αβγδε]]+suffix/v;
       const partial = createPartialMatchRegex(input);
       expect(partial).toMatchPartially({
         characters: ["α", "β", "γ", "δ", "ε", ..."suffix".split("")]
+      });
+    });
+
+    it("should support partial matching of union in unicode set character class expressions", () => {
+      const input = /[[\p{Script_Extensions=Greek}][xyz]]+suffix/v;
+      const partial = createPartialMatchRegex(input);
+      expect(partial).toMatchPartially({
+        characters: ["α", "β", "δ", "ε", "x", "y", "z", ..."suffix".split("")]
       });
     });
 


### PR DESCRIPTION
# Issue

resolves #29 

## Details

- Add note that UnicodeSets requires ES2024+ for browser support

## Semantic Version Impact

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## Scout rule

- Allow semver selection in ci workflow to support case-insensitive checkboxes, since that's what's valid in Github Flavoured Markdown
- Add missing "Character Class Escapes" to supported features
- Fixup some test cases for unicode sets
  - character class wrapping escapes, since this differentiates from `u` flag
  - missing tests for unions
  - complement syntax

## CheckList

- [x] PR starts with [_ISSUE_ID_]
- [x] I have added an entry to the `[Unreleased]` section in `docs/CHANGELOG.md`
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
