### PR TITLE
[31] add test for \q sequence, and docs around partial matching string properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Such combinations have not been tested.
 - 🔢 [Quantifiers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Quantifier) (`*`, `+`, `?`, `{n}`, `{n,}`, `{n,m}`)
 - 🔀 [Disjunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction) (`a|b`)
 - 👥 [Groups](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Capturing_group) (capturing and non-capturing) (`(?:abc)`, `(abc)`, `(?<named>abc)`)
-- 👀 [Lookahead assertions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion) (`(?=...)`, `(?!...)`)
+- 👉 [Lookahead assertions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion) (`(?=...)`, `(?!...)`)
 - 👈 [Lookbehind assertions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion) (`(?<=...)`, `(?<!...)`)
 - ⚓ [Input Boundaries](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Input_boundary_assertion) (`^`, `$`)
 - 🆒 [Word Boundaries](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Word_boundary_assertion) (`\b`, `\B`)
@@ -88,6 +88,7 @@ Such combinations have not been tested.
 The following regex features are **not currently supported**:
 
 - ⚠️ [Backreferences](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Backreference) (`\1`, `\k<name>`) - Can be included, but can't partially match. See [caveats](#caveats).
+- ⚠️ [Character class substrings](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class#matching_strings) (`\q{abc}`) - When used independently, rather than to modify, can be included, but can't partially match. See [caveats](#caveats).
 - ❌ [Modifiers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Modifier) (`(?ims:...)`, `(?-ims:...)`) - ES2025+. See [issue](https://github.com/TomStrepsil/regex-partial-match/issues/2).
 
 ## Browser Compatibility
@@ -179,6 +180,14 @@ partial.test("he"); // succeeds, but lastIndex was reset by previous test
 The **global flag is preserved** but may not be necessary for partial matching use cases. The `g` flag affects behavior when using `.exec()` repeatedly to find all matches, but partial matching typically validates a single prefix at a time.
 
 The global flag does not cause issues like the sticky flag, as partial patterns naturally match from the beginning of the input. However, if you're using `lastIndex` to track position, be aware that failed matches will reset it to 0.
+
+### "String properties"
+
+As with surrogate pair matching, grapheme clusters / string properties can only match atomically.
+
+Hence, `[\p{RGI_Emoji_Flag_Sequence}]` will match `🇺🇳` as a whole, but not as the individual code points of which its comprised.
+
+In [`v` mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) expressions, where `[\q{abc}]` syntax is used in isolation (rather than its canonical use-case as a subtraction/intersection of another character class), this will also only match entirely or not at all.   i.e. `abc` can match, but not partially.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -185,9 +185,9 @@ The global flag does not cause issues like the sticky flag, as partial patterns 
 
 As with surrogate pair matching, grapheme clusters / string properties can only match atomically.
 
-Hence, `[\p{RGI_Emoji_Flag_Sequence}]` will match `🇺🇳` as a whole, but not as the individual code points of which its comprised.
+Hence, `[\p{RGI_Emoji_Flag_Sequence}]` will match `🇺🇳` as a whole, but not as the individual code points of which it's comprised.
 
-In [`v` mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) expressions, where `[\q{abc}]` syntax is used in isolation (rather than its canonical use-case as a subtraction/intersection of another character class), this will also only match entirely or not at all.   i.e. `abc` can match, but not partially.
+In [`v` mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) expressions, where `[\q{abc}]` syntax is used in isolation (rather than its canonical use-case as a subtraction/intersection of another character class), this will also only match entirely or not at all. i.e. `abc` can match, but not partially.
 
 ## Examples
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add note to `README.md` that `unicodeSets` / `v` flag requires ES2024+ for browser support
+- Note to `README.md` that `unicodeSets` / `v` flag requires ES2024+ for browser support
+- Test to cover [string literals in character classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class#v-mode_character_class:~:text=a%20%22string%20literal%22%20in%20a%20character%20class) when used in `v` flag expressions, as a subtraction with disjunction
+- Documentation of caveats around "string properties" and partial matching
 
 ### Fixed
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -525,6 +525,16 @@ describe("regexp-partial-match", () => {
       expect(partial.exec("A")).toNotMatch();
     });
 
+    it("should support partial matching of grapheme clusters / string properties including string subtraction (with caveat that individual code points do not match independently)", () => {
+      const input = /[\p{RGI_Emoji_Flag_Sequence}--\q{🇺🇸|🇷🇺}]suffix/v;
+      const partial = createPartialMatchRegex(input);
+      expect(partial).toMatchPartially({
+        characters: ["🇺🇦", ..."suffix".split("")] // "🇺🇦".length === 4
+      });
+      expect(partial.exec("🇺🇸")).toNotMatch();
+      expect(partial.exec("🇷🇺")).toNotMatch();
+    });
+
     it("should support partial matching of unicode set expressions using key/value syntax", () => {
       const input = /[\p{Script=Hiragana}]+suffix/v;
       const partial = createPartialMatchRegex(input);


### PR DESCRIPTION
# Issue

resolves #31

## Details

Add documentation around `\q` / string sequences and partial matching.

## Semantic Version Impact

_Select ONE checkbox to indicate the semver impact of this change. Learn more at https://semver.org/. If multiple are selected, **MAJOR** takes precedence over **MINOR**, which takes precedence over **PATCH**._

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## Scout rule

- Changed the "lookahead" emoji in the `README.md`, for symmetry with `lookbehind`

## CheckList

- [x] PR starts with [_ISSUE_ID_]
- [x] I have added an entry to the `[Unreleased]` section in `docs/CHANGELOG.md`
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
