### PR TITLE
[34] remove extended pictographic from test

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright 2025 Tom Pereira (https://github.com/TomStrepsil)
+Copyright 2025-2026 Tom Pereira (https://github.com/TomStrepsil)
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Hence:
 
 To mitigate, a start boundary anchor can prevent anything _but_ an empty string matching:
 
-```ts
+```js
 /^(?:x|$)/.test("") === true;
 /^(?:x|$)/.test("x") === true;
 /^(?:x|$)/.test("a") === false;

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This allows the pattern to match prefixes of the original pattern, enabling vali
 
 Since the library accepts only valid regular expressions [^1], this enables the algorithm to make lots of unguarded assumptions about the source of the expression.
 
-The library has been stress-tested with various regular expression features in isolation, and some in likely combination, but obviously its an unbounded test space, and syntactically valid regular expressions nevertheless support contradictory patterns e.g.
+The library has been stress-tested with various regular expression features in isolation, and some in likely combination, but obviously it's an unbounded test space, and syntactically valid regular expressions nevertheless support contradictory patterns e.g.
 
 - `/\b\B/` - impossible to match both a word boundary and a non-word boundary
 - `/$^/` - end cannot come before start
@@ -119,7 +119,7 @@ Hence:
 
 To mitigate, a start boundary anchor can prevent anything _but_ an empty string matching:
 
-```js
+```ts
 /^(?:x|$)/.test("") === true;
 /^(?:x|$)/.test("x") === true;
 /^(?:x|$)/.test("a") === false;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected test to remove `Extended_Pictographic`, the definition of which varies between runtimes
+  - Bun is "correct" / adheres to [Unicode 17](https://www.unicode.org/Public/17.0.0/ucd/emoji/emoji-data.txt), others approximate
+
 ## [0.3.0] - 2026-02-03
 
 ### Added

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,16 +50,14 @@ Wait for feedback before starting significant work to ensure your contribution a
 ### 1. Create a Branch
 
 ```bash
-git checkout -b feature/your-feature-name
-# or
-git checkout -b fix/your-bug-fix
+git checkout -b <issue>_your-feature-name
 ```
 
 Use descriptive branch names:
 
-- `feature/add-unicode-normalization`
-- `fix/handle-empty-patterns`
-- `docs/improve-readme-examples`
+- `123_add-unicode-normalization`
+- `456_handle-empty-patterns`
+- `789_improve-readme-examples`
 
 ### 2. Make Your Changes
 
@@ -105,7 +103,7 @@ git merge upstream/main
 ### 7. Push to Your Fork
 
 ```bash
-git push origin feature/your-feature-name
+git push origin issue_your-feature-name
 ```
 
 ## Submitting a Pull Request

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Wait for feedback before starting significant work to ensure your contribution a
 ### 1. Create a Branch
 
 ```bash
-git checkout -b <issue>_your-feature-name
+git checkout -b {issue}_your-feature-name
 ```
 
 Use descriptive branch names:
@@ -103,7 +103,7 @@ git merge upstream/main
 ### 7. Push to Your Fork
 
 ```bash
-git push origin issue_your-feature-name
+git push origin {issue}_your-feature-name
 ```
 
 ## Submitting a Pull Request

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -716,7 +716,7 @@ describe("regexp-partial-match", () => {
       });
     });
 
-    it("should support partial matching of emoji property with nested subtraction in unicode set character class expressions", () => {  
+    it("should support partial matching of emoji property with nested subtraction in unicode set character class expressions", () => {
       const input =
         /^[[\p{Emoji}]--[[\p{Emoji_Presentation}]--[😀😃😄]]]+suffix/v;
       const partial = createPartialMatchRegex(input);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -716,12 +716,12 @@ describe("regexp-partial-match", () => {
       });
     });
 
-    it("should support partial matching of extended pictographic property with nested subtraction in unicode set character class expressions", () => {
+    it("should support partial matching of emoji property with nested subtraction in unicode set character class expressions", () => {  
       const input =
-        /^[[\p{Extended_Pictographic}]--[[\p{Emoji}]--[😀😃😄]]]+suffix/v;
+        /^[[\p{Emoji}]--[[\p{Emoji_Presentation}]--[😀😃😄]]]+suffix/v;
       const partial = createPartialMatchRegex(input);
       expect(partial).toMatchPartially({
-        characters: ["♡", "😀", ..."suffix".split("")]
+        characters: ["⚙", "✂", "😀", ..."suffix".split("")]
       });
       expect(partial).toNotMatchPartially({
         characters: ["💀", "💣", ..."suffix".split("")]


### PR DESCRIPTION
# Issue

resolves #34

## Details

Remove use of `Extended_Pictographic` in a nested subtraction unicode set character class expression test.

## Semantic Version Impact

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## Scout rule

- Add end date to Copyright notice
- Fix typo in README
- Align CONTRIBUTING.md to branch naming convention

## CheckList

- [x] PR starts with [_ISSUE_ID_]
- [x] I have added an entry to the `[Unreleased]` section in `docs/CHANGELOG.md`
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
