### PR TITLE
[36] Support pass-through of multi-digit numeric backreferences

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Corrected test to remove `Extended_Pictographic`, the definition of which varies between runtimes
   - Bun is "correct" / adheres to [Unicode 17](https://www.unicode.org/Public/17.0.0/ucd/emoji/emoji-data.txt), others approximate
+- Support pass-through of multi-digit [numeric back-references](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Backreference)
 
 ## [0.3.0] - 2026-02-03
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1226,7 +1226,7 @@ c`)
   });
 
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Backreference
-  describe.only("backreferences", () => {
+  describe("backreferences", () => {
     [
       {
         name: "simple backreference, at end of string",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -761,14 +761,18 @@ describe("regexp-partial-match", () => {
       expect(partial).toMatchPartially({
         characters: ["a", "\n", "c", ..."suffix".split("")]
       });
-      expect(partial.exec(`a
-csuffix`)).toMatchAt({
+      expect(
+        partial.exec(`a
+csuffix`)
+      ).toMatchAt({
         match: `a
 csuffix`,
         index: 0
       });
-      expect(partial.exec(`abcsuf
-ix`)).not.toMatchAt({
+      expect(
+        partial.exec(`abcsuf
+ix`)
+      ).not.toMatchAt({
         match: `abcsuf
 ix`,
         index: 0
@@ -790,9 +794,16 @@ ix`,
       expect(partial).toMatchPartially({
         characters: ["A", "\n", "C", "\n", ..."suffix".split("")]
       });
-      expect(partial.exec(`ABC\nS`)).not.toMatchAt({ match: "ABC\nS", index: 0 }); // s not modified to case-insensitive
-      expect(createPartialMatchRegex(/(?ism:^abc$).suffix/).exec(`ABC\nS`)).not.toMatchAt({ match: "ABC\nS", index: 0 }); // . not modified to match newlines
-      expect(createPartialMatchRegex(/(?ism:^abc$)\n^suffix/).exec(`ABC\nS`)).not.toMatchAt({ match: "ABC\ns", index: 0 }); // ^ not modified to multiline
+      expect(partial.exec(`ABC\nS`)).not.toMatchAt({
+        match: "ABC\nS",
+        index: 0
+      }); // s not modified to case-insensitive
+      expect(
+        createPartialMatchRegex(/(?ism:^abc$).suffix/).exec(`ABC\nS`)
+      ).not.toMatchAt({ match: "ABC\nS", index: 0 }); // . not modified to match newlines
+      expect(
+        createPartialMatchRegex(/(?ism:^abc$)\n^suffix/).exec(`ABC\nS`)
+      ).not.toMatchAt({ match: "ABC\ns", index: 0 }); // ^ not modified to multiline
     });
 
     it("should support partial matching of patterns with a negating case insensitive modifier", () => {
@@ -810,8 +821,10 @@ ix`,
       expect(partial).toMatchPartially({
         characters: ["a", "b", "c", ..."suffix".split("")]
       });
-      expect(partial.exec(`a
-c`)).toNotMatch();
+      expect(
+        partial.exec(`a
+c`)
+      ).toNotMatch();
     });
 
     it("should prevent partial matching of patterns with a negating multiline modifier", () => {
@@ -846,7 +859,10 @@ c`)).toNotMatch();
       expect(partial).toMatchPartially({
         characters: ["A", "b", "C", "\n", ..."suffix".split("")]
       });
-      expect(partial.exec(`ABC\nsuffix`)).toMatchAt({ match: "ABC\nsuffix", index: 0 });
+      expect(partial.exec(`ABC\nsuffix`)).toMatchAt({
+        match: "ABC\nsuffix",
+        index: 0
+      });
       expect(partial.exec(`A\nC`)).toNotMatch(); // dot-all disabled
     });
   });
@@ -1206,6 +1222,69 @@ c`)).toNotMatch();
 
       expect(partial.exec("xfooy")).toMatchAt({ match: "foo", index: 1 });
       expect(partial.exec(" foo ")).toNotMatch();
+    });
+  });
+
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Backreference
+  describe.only("backreferences", () => {
+    [
+      {
+        name: "simple backreference, at end of string",
+        input: /(a)\1/,
+        testStrings: ["a", "aa"],
+        expected: (str: string) => ({ 0: str, 1: "a" })
+      },
+      {
+        name: "simple backreference, not at end of string",
+        input: /(a)\1b/,
+        testStrings: ["a", "aa", "aab"],
+        expected: (str: string) => ({ 0: str, 1: "a" })
+      },
+      {
+        name: "backreference with disjunction",
+        input: /(a|b)\1/,
+        testStrings: ["a", "aa", "b", "bb"],
+        expected: ([char]: string) => ({ 1: char })
+      },
+      {
+        name: "nested backreferences",
+        input: /((a))\2\1/,
+        testStrings: ["a", "aa", "aaa"],
+        expected: () => ({ 1: "a", 2: "a" })
+      },
+      {
+        name: "two-digit backreference",
+        input: /((((((((((a))))))))))\10/,
+        testStrings: ["a", "aa"],
+        expected: () => ({
+          10: "a"
+        })
+      },
+      {
+        name: "three-digit backreference",
+        input:
+          /((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((a))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))\100/,
+        testStrings: ["a", "aa"],
+        expected: () => ({
+          100: "a"
+        })
+      },
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_backreference
+      {
+        name: "named backreference",
+        input: /(?<char>a)\k<char>/,
+        testStrings: ["a", "aa"],
+        expected: (str: string) => ({ 0: str, groups: { char: "a" } })
+      }
+    ].forEach(({ name, input, testStrings, expected }) => {
+      it(`should support pass-through of ${name} (despite not being able to partially match non-atomic captures, since matching is atomic)`, () => {
+        const partial = createPartialMatchRegex(input);
+        for (const testString of testStrings) {
+          const result = partial.exec(testString);
+          expect(result).toMatchAt({ match: testString, index: 0 });
+          expect(result).toMatchObject(expected(testString));
+        }
+      });
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 const occurrencesRegex = /\{\d+,?\d*\}/g;
+const notNumbersRegex = /\D/g;
 
 const createPartialMatchRegex = (regex: RegExp): RegExp => {
   const source = regex.source;
@@ -48,6 +49,21 @@ const createPartialMatchRegex = (regex: RegExp): RegExp => {
               break;
             case "x":
               appendOptional(4);
+              break;
+            case "1":
+            case "2":
+            case "3":
+            case "4":
+            case "5":
+            case "6":
+            case "7":
+            case "8":
+            case "9":
+              notNumbersRegex.lastIndex = i + 1;
+              const nextNonDigit = notNumbersRegex.exec(source);
+              appendOptional(
+                (nextNonDigit ? nextNonDigit.index : source.length) - i
+              );
               break;
             default:
               appendOptional(2);
@@ -110,7 +126,8 @@ const createPartialMatchRegex = (regex: RegExp): RegExp => {
               case "i":
               case "s":
               case "m":
-                const temp = i + 2, temp2 = source.indexOf(":", temp);
+                const temp = i + 2,
+                  temp2 = source.indexOf(":", temp);
                 result += "(?" + source.substring(temp, temp2) + ":";
                 i = temp2 + 1;
                 result += process() + ")";


### PR DESCRIPTION

# Issue

resolves #36

## Details

- Add tests for pass through of named and numeric back-references, previously un-tested & caught by the "deafult" case
- Augment the handling of backslash to recognise multi-digit numeric back-references, recognising all digits as the atomic unit

## Semantic Version Impact

- [ ] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [x] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## Scout rule

- some IDE-opinionated formatting

## CheckList

- [x] PR starts with [_ISSUE_ID_]
- [x] I have added an entry to the `[Unreleased]` section in `docs/CHANGELOG.md`
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
