### PR TITLE
[14] Ensure ergonomic expectation for .test(), ensuring patterns without end-of-input boundary assertions don't always match

### DIFF
--- a/.github/actions/run-benchmarks/action.yml
+++ b/.github/actions/run-benchmarks/action.yml
@@ -1,0 +1,35 @@
+name: Run benchmarks
+
+description: Run mitata benchmarks and store/compare results via github-action-benchmark
+
+inputs:
+  github-token:
+    required: true
+  auto-push:
+    required: true
+  comment-on-alert:
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Run benchmarks
+      run: corepack npm run bench --workspace=benchmarking --silent -- --json > /tmp/bench-raw.json
+      shell: bash
+
+    - name: Convert to action format
+      run: cd benchmarking && npx tsx ../.github/scripts/mitata-to-action-format.ts < /tmp/bench-raw.json > results.json
+      shell: bash
+
+    - name: Store / compare benchmark results
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        name: regex-partial-match
+        tool: customSmallerIsBetter
+        output-file-path: benchmarking/results.json
+        github-token: ${{ inputs.github-token }}
+        auto-push: ${{ inputs.auto-push }}
+        comment-on-alert: ${{ inputs.comment-on-alert }}
+        alert-threshold: "150%"
+        fail-on-alert: false

--- a/.github/actions/run-benchmarks/action.yml
+++ b/.github/actions/run-benchmarks/action.yml
@@ -19,7 +19,7 @@ runs:
       shell: bash
 
     - name: Convert to action format
-      run: cd benchmarking && npx tsx ../.github/scripts/mitata-to-action-format.ts < /tmp/bench-raw.json > results.json
+      run: npx tsx .github/scripts/mitata-to-action-format.ts < /tmp/bench-raw.json > /tmp/bench-results.json
       shell: bash
 
     - name: Store / compare benchmark results
@@ -27,7 +27,7 @@ runs:
       with:
         name: regex-partial-match
         tool: customSmallerIsBetter
-        output-file-path: benchmarking/results.json
+        output-file-path: /tmp/bench-results.json
         github-token: ${{ inputs.github-token }}
         auto-push: ${{ inputs.auto-push }}
         comment-on-alert: ${{ inputs.comment-on-alert }}

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -6,7 +6,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version-file: .nvmrc
         package-manager-cache: false

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -6,7 +6,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@v6
       with:
         node-version-file: .nvmrc
         package-manager-cache: false

--- a/.github/scripts/mitata-to-action-format.ts
+++ b/.github/scripts/mitata-to-action-format.ts
@@ -1,30 +1,39 @@
 /**
- * Converts mitata JSON output to the github-action-benchmark
+ * Converts mitata v1.x JSON output to the github-action-benchmark
  * customSmallerIsBetter format. Called by the benchmark workflow:
  *
- *   npm run bench --workspace=benchmarking -- --json \
- *     | npx tsx .github/scripts/to-action-format.ts > benchmarking/results.json
+ *   npm run bench --workspace=benchmarking --silent -- --json \
+ *     | npx tsx .github/scripts/mitata-to-action-format.ts > benchmarking/results.json
  *
- * Input (stdin): mitata run() result — { benchmarks: [...] } (v1.x)
+ * Input (stdin): mitata run() result — { benchmarks: [...], layout: [...] }
  * Output (stdout): JSON array of:
  *   { name: string, value: number, unit: "ns/iter", range: string, extra: string }
+ *
+ * v1.x notes:
+ *   - Stats are at benchmarks[].runs[0].stats (not top-level on the benchmark)
+ *   - Values are already in nanoseconds
+ *   - No stddev field; (p75 - p25) / 2 is used as spread
+ *   - group is a numeric index into the layout array, not a group name string
  */
-
-const SEC_TO_NS = 1e9;
 
 interface MitataStats {
   avg: number;
   min: number;
   max: number;
+  p25: number;
   p75: number;
   p99: number;
-  stddev: number;
 }
 
 interface MitataBenchmark {
-  name: string;
-  group?: string;
-  stats?: MitataStats;
+  alias: string;
+  group?: number;
+  runs: Array<{ stats: MitataStats }>;
+}
+
+interface MitataOutput {
+  benchmarks: MitataBenchmark[];
+  layout: Array<{ name: string | null }>;
 }
 
 interface ActionEntry {
@@ -39,26 +48,25 @@ process.stdin.setEncoding("utf8");
 
 let input = "";
 for await (const chunk of process.stdin) {
-  input += chunk;
+  input += String(chunk);
 }
-const raw: unknown = JSON.parse(input);
+const { benchmarks, layout } = JSON.parse(input) as MitataOutput;
 
-const benchmarks: MitataBenchmark[] = Array.isArray(raw)
-  ? (raw as MitataBenchmark[])
-  : ((raw as { benchmarks?: MitataBenchmark[] }).benchmarks ?? []);
+const fmt = (v: number) => v.toFixed(2);
 
 const output: ActionEntry[] = benchmarks
-  .filter((b): b is MitataBenchmark & { stats: MitataStats } => b.stats != null)
+  .filter((b) => b.runs.length > 0)
   .map((b) => {
-    const label = b.group ? `${b.group} — ${b.name}` : b.name;
-    const toNs = (s: number) => +(s * SEC_TO_NS).toFixed(2);
-    const ns = (s: number) => toNs(s).toString();
+    const stats = b.runs[0].stats;
+    const groupName = b.group !== undefined ? layout[b.group].name : null;
+    const label = groupName !== null ? `${groupName} — ${b.alias}` : b.alias;
+    const spread = (stats.p75 - stats.p25) / 2;
     return {
       name: label,
-      value: toNs(b.stats.avg),
+      value: +fmt(stats.avg),
       unit: "ns/iter",
-      range: `± ${ns(b.stats.stddev)}`,
-      extra: `min: ${ns(b.stats.min)}ns  p75: ${ns(b.stats.p75)}ns  p99: ${ns(b.stats.p99)}ns`,
+      range: `± ${fmt(spread)}`,
+      extra: `min: ${fmt(stats.min)}ns  p75: ${fmt(stats.p75)}ns  p99: ${fmt(stats.p99)}ns`,
     };
   });
 

--- a/.github/scripts/mitata-to-action-format.ts
+++ b/.github/scripts/mitata-to-action-format.ts
@@ -1,19 +1,13 @@
 /**
- * Converts mitata JSON output (from `tsx src/run.ts --json`) to the
- * github-action-benchmark customSmallerIsBetter format.
+ * Converts mitata JSON output to the github-action-benchmark
+ * customSmallerIsBetter format. Called by the benchmark workflow:
  *
- * Input (stdin): mitata run() result — either an array of benchmarks or
- *   { benchmarks: [...] } depending on mitata version.
+ *   npm run bench --workspace=benchmarking -- --json \
+ *     | npx tsx .github/scripts/to-action-format.ts > benchmarking/results.json
  *
+ * Input (stdin): mitata run() result — { benchmarks: [...] } (v1.x)
  * Output (stdout): JSON array of:
  *   { name: string, value: number, unit: "ns/iter", range: string, extra: string }
- *
- * mitata reports time in seconds internally. This script normalises to ns/iter.
- * If your mitata version reports in nanoseconds (value > 1 for typical bench),
- * set SEC_TO_NS = 1 below.
- *
- * Usage:
- *   tsx src/run.ts --json | tsx scripts/to-action-format.ts > results.json
  */
 
 const SEC_TO_NS = 1e9;

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,11 +11,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  benchmark:
-    name: Run benchmarks
+  benchmark-pr:
+    name: Run benchmarks (PR)
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
 
     steps:
@@ -37,7 +38,37 @@ jobs:
           tool: customSmallerIsBetter
           output-file-path: benchmarking/results.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          auto-push: false
           comment-on-alert: true
+          alert-threshold: "150%"
+          fail-on-alert: false
+
+  benchmark-main:
+    name: Run benchmarks (main)
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+
+      - name: Run benchmarks
+        run: corepack npm run bench --workspace=benchmarking -- --json > /tmp/bench-raw.json
+
+      - name: Convert to action format
+        run: cd benchmarking && npx tsx ../.github/scripts/mitata-to-action-format.ts < /tmp/bench-raw.json > results.json
+
+      - name: Store / compare benchmark results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: regex-partial-match
+          tool: customSmallerIsBetter
+          output-file-path: benchmarking/results.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
           alert-threshold: "150%"
           fail-on-alert: false

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
         uses: ./.github/actions/setup-node

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,40 @@
+name: Benchmarks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: bench-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+
+      - name: Run benchmarks (JSON output)
+        run: corepack npm run bench:ci --workspace=benchmarking
+
+      - name: Store / compare benchmark results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: regex-partial-match
+          tool: customSmallerIsBetter
+          output-file-path: benchmarking/results.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          comment-on-alert: true
+          alert-threshold: "150%"
+          fail-on-alert: false

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,27 +21,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-
-      - name: Setup Node
-        uses: ./.github/actions/setup-node
-
-      - name: Run benchmarks
-        run: corepack npm run bench --workspace=benchmarking --silent -- --json > /tmp/bench-raw.json
-
-      - name: Convert to action format
-        run: cd benchmarking && npx tsx ../.github/scripts/mitata-to-action-format.ts < /tmp/bench-raw.json > results.json
-
-      - name: Store / compare benchmark results
-        uses: benchmark-action/github-action-benchmark@v1
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/run-benchmarks
         with:
-          name: regex-partial-match
-          tool: customSmallerIsBetter
-          output-file-path: benchmarking/results.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: false
           comment-on-alert: true
-          alert-threshold: "150%"
-          fail-on-alert: false
 
   benchmark-main:
     name: Run benchmarks (main)
@@ -52,23 +37,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-
-      - name: Setup Node
-        uses: ./.github/actions/setup-node
-
-      - name: Run benchmarks
-        run: corepack npm run bench --workspace=benchmarking --silent -- --json > /tmp/bench-raw.json
-
-      - name: Convert to action format
-        run: cd benchmarking && npx tsx ../.github/scripts/mitata-to-action-format.ts < /tmp/bench-raw.json > results.json
-
-      - name: Store / compare benchmark results
-        uses: benchmark-action/github-action-benchmark@v1
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/run-benchmarks
         with:
-          name: regex-partial-match
-          tool: customSmallerIsBetter
-          output-file-path: benchmarking/results.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
-          alert-threshold: "150%"
-          fail-on-alert: false

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Run benchmarks
-        run: corepack npm run bench --workspace=benchmarking -- --json > /tmp/bench-raw.json
+        run: corepack npm run bench --workspace=benchmarking --silent -- --json > /tmp/bench-raw.json
 
       - name: Convert to action format
         run: cd benchmarking && npx tsx ../.github/scripts/mitata-to-action-format.ts < /tmp/bench-raw.json > results.json
@@ -57,7 +57,7 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Run benchmarks
-        run: corepack npm run bench --workspace=benchmarking -- --json > /tmp/bench-raw.json
+        run: corepack npm run bench --workspace=benchmarking --silent -- --json > /tmp/bench-raw.json
 
       - name: Convert to action format
         run: cd benchmarking && npx tsx ../.github/scripts/mitata-to-action-format.ts < /tmp/bench-raw.json > results.json

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,8 +24,11 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
-      - name: Run benchmarks (JSON output)
-        run: corepack npm run bench:ci --workspace=benchmarking
+      - name: Run benchmarks
+        run: corepack npm run bench --workspace=benchmarking -- --json > /tmp/bench-raw.json
+
+      - name: Convert to action format
+        run: cd benchmarking && npx tsx ../.github/scripts/mitata-to-action-format.ts < /tmp/bench-raw.json > results.json
 
       - name: Store / compare benchmark results
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           sparse-checkout: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node
         uses: ./.github/actions/setup-node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
           git push origin "v${{ steps.npm_version.outputs.version }}"
 
       - name: Create Draft GitHub Release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const tagName = 'v${{ steps.npm_version.outputs.version }}';

--- a/README.md
+++ b/README.md
@@ -23,10 +23,9 @@ npm install regex-partial-match
 ### Basic Usage
 
 ```javascript
-import createPartialMatchRegex from "regex-partial-match";
+import PartialMatchRegExp from "regex-partial-match";
 
-const pattern = /hello world/;
-const partial = createPartialMatchRegex(pattern);
+const partial = new PartialMatchRegExp(/hello world/);
 
 partial.test("h"); // true - could match
 partial.test("hello"); // true - could match
@@ -39,14 +38,14 @@ partial.test("goodbye"); // false - cannot match
 ```javascript
 import "regex-partial-match/extend";
 
-const partial = /hello world/.toPartialMatchRegex();
+const partial = /hello world/.toPartialMatchRegex(); // returns a PartialMatchRegExp
 
 partial.test("hel"); // true
 ```
 
 ## How It Works
 
-The library transforms a regular expression by wrapping each atomic element in a non-capturing group with an alternation to end-of-input (`$`):
+The library transforms a regular expression by wrapping each [atomic element](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions#atoms) in a [non-capturing group](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Non-capturing_group) with a [disjunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction) to [end-of-input](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Input_boundary_assertion) (`$`):
 
 ```javascript
 /abc/ → /(?:a|$)(?:b|$)(?:c|$)/
@@ -63,8 +62,6 @@ The library has been stress-tested with various regular expression features in i
 - `x{2}?` - lazy quantifiers are mutually exclusive to fixed-length assertions
 
 Such combinations have not been tested.
-
-[^1]: To remain lightweight, no runtime type validation is applied, so non-typescript consumers will be reliant on underlying errors thrown, if used incorrectly.
 
 ## Supported Features
 
@@ -106,41 +103,27 @@ The library is compiled to **ES5** for broad compatibility with older browsers a
 
 ## Caveats
 
-### [`.test()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) behaviour and non-matching results from [`.exec()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) and [`.match()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match)
+### [`.test()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) and empty-input behaviour
 
-The library produces an expression that always matches an empty string, at the end of the input. Feasibly, this is the start of a new partial match.
-
-Hence:
+The partial transform produces a pattern that can match an empty string at the end of input (via the `|$` sentinel). `PartialMatchRegExp` suppresses these sentinel matches — an empty match at `index === input.length` is treated as `null`, so `test()` and `exec()` behave as expected for non-matching strings:
 
 ```js
-/x/.test("a") === false; /* untransformed regex */
-/(?:x|$)/.test("a") === true; /* what's produced by the library */
+const re = new PartialMatchRegExp(/^foo/);
+re.test("bar"); // false — cannot match
+re.test("fo");  // true  — valid prefix
+re.test("foo"); // true  — full match
+re.test("");    // false — pattern does not accept empty string
 ```
 
-To mitigate, a start boundary anchor can prevent anything _but_ an empty string matching:
-
-```js
-/^(?:x|$)/.test("") === true;
-/^(?:x|$)/.test("x") === true;
-/^(?:x|$)/.test("a") === false;
-```
-
-On this basis, `.test()` should be used with caution, and a match of an empty string at the end of the input should instead be considered "no match", if validating that which came before.
-
-i.e.
-
-```js
-/(?:x|$)/.exec("a"); // ['', index: 1, input: "a", groups: undefined];
-"a".match(/(?:x|$)/); // ['', index: 1, input: "a", groups: undefined];
-```
-
-Since the library produces a native `RegExp` object, no attempt to proxy / translate this output to `null` has been attempted, but a helper could be produced in future, for clarity. See [issue](https://github.com/TomStrepsil/regex-partial-match/issues/14).
+`test("")` reflects whether the original pattern matches the empty string. Patterns like `/^a*/` or `/^$/` do accept `""`, so `test("")` returns `true` for those. Patterns that require at least one character return `false`.
 
 ### Backreferences
 
 **Backreferences cannot be partially matched because they are atomic.** A backreference like `\1` must match the complete captured text or fail entirely, and cannot be split into individual characters for partial matching like regular atoms can.
 
 Fixed-length patterns like `/(abc)\1/` could theoretically become `/(?:(a)|$)(?:(b)|$)(?:(c)|$)(?:\1|$)(?:\2|$)(?:\3|$)/` (accepting polluted capture indexes as a side-effect), but this doesn't work for variable-length captures.
+
+[^1]: To remain lightweight, no runtime type validation is applied, so non-typescript consumers will be reliant on underlying errors thrown, if used incorrectly.
 
 ### Positive Lookbehinds
 
@@ -165,10 +148,11 @@ The **sticky flag may not behave as expected** in partial matching scenarios. Th
 **Example:**
 
 ```javascript
-const pattern = /hello/y;
-const partial = createPartialMatchRegex(pattern);
+import PartialMatchRegExp from "regex-partial-match";
 
-pattern.lastIndex = 0;
+const partial = new PartialMatchRegExp(/hello/y);
+
+partial.lastIndex = 0;
 partial.test("h"); // succeeds, lastIndex advances
 partial.test("he"); // succeeds, but lastIndex was reset by previous test
 // Cannot reliably continue partial matching with sticky flag
@@ -178,7 +162,7 @@ partial.test("he"); // succeeds, but lastIndex was reset by previous test
 
 ### Global Flag (`g`)
 
-The **global flag is preserved** but may not be necessary for partial matching use cases. The `g` flag affects behavior when using `.exec()` repeatedly to find all matches, but partial matching typically validates a single prefix at a time.
+The **global flag is preserved** but may not be necessary for partial matching use cases. The `g` flag affects behaviour when using `.exec()` repeatedly to find all matches, but partial matching typically validates a single prefix at a time.
 
 The global flag does not cause issues like the sticky flag, as partial patterns naturally match from the beginning of the input. However, if you're using `lastIndex` to track position, be aware that failed matches will reset it to 0.
 
@@ -195,8 +179,9 @@ In [`v` mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/
 ### Form Validation
 
 ```javascript
-const emailPattern = /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/i;
-const partial = createPartialMatchRegex(emailPattern);
+import PartialMatchRegExp from "regex-partial-match";
+
+const partial = new PartialMatchRegExp(/^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/i);
 
 function validateEmail(input) {
   return partial.test(input) ? "valid" : "invalid";
@@ -212,8 +197,9 @@ validateEmail("@@invalid"); // 'invalid' - cannot match
 ### Autocomplete
 
 ```javascript
-const commandPattern = /^(help|quit|save|load)/;
-const partial = createPartialMatchRegex(commandPattern);
+import PartialMatchRegExp from "regex-partial-match";
+
+const partial = new PartialMatchRegExp(/^(help|quit|save|load)/);
 
 function getSuggestions(input) {
   return partial.test(input) ? "valid prefix" : "no suggestions";
@@ -230,7 +216,7 @@ getSuggestions("xyz"); // 'no suggestions'
 ```javascript
 // Process streaming data with pattern matching at chunk boundaries
 const pattern = /\{"[^"]+":"[^"]+"\}/; // Match JSON objects
-const partial = createPartialMatchRegex(pattern);
+const partial = new PartialMatchRegExp(pattern);
 let buffer = "";
 
 function processChunk(chunk) {
@@ -263,27 +249,27 @@ Useful for parsing log files, network streams, or any chunked data where records
 
 ## API
 
-### `createPartialMatchRegex(regex: RegExp): RegExp`
+### `PartialMatchRegExp`
 
-Transforms a regular expression to support partial matching.
+A `RegExp` subclass that supports partial matching. The default export of the package.
 
-Available via the default entry point of the package.
+```js
+import PartialMatchRegExp from "regex-partial-match";
 
-**Parameters:**
+const re = new PartialMatchRegExp(/^(ab)+/);
+// or
+const re = new PartialMatchRegExp("^(ab)+", "i");
+```
 
-- `regex` - The regular expression to transform
+Accepts the same constructor arguments as `RegExp`. For any string `s` that is a valid prefix of a string that would produce a complete match, `exec(s)` returns a non-null result whose captures are as consistent as possible with what the original `RegExp` would return on the completed input; for non-matching inputs it returns `null`.
 
-**Returns:**
-
-- A new `RegExp` that matches partial strings
-
-### `RegExp.prototype.toPartialMatchRegex(): RegExp`
+### `RegExp.prototype.toPartialMatchRegex(): PartialMatchRegExp`
 
 When using `import 'regex-partial-match/extend'`, this method is added to `RegExp.prototype`.
 
 **Returns:**
 
-- A new `RegExp` that matches partial strings, created from the `RegExp` instance the method was called on.
+- A new `PartialMatchRegExp` created from the `RegExp` instance the method was called on.
 
 ## License
 
@@ -297,13 +283,97 @@ Algorithm created by [Lucas Trzesniewski](https://github.com/ltrzesniewski).
 
 Contributions are welcome! Please open an issue or pull request on [GitHub](https://github.com/TomStrepsil/regex-partial-match).
 
+## Compatibility with other partial-match implementations
+
+Several widely-used regex libraries offer native partial-match support. This section maps their concepts and test cases to this library's behaviour.
+
+> **Provenance note:** The parity tests added in `src/index.test.ts` ("parity with reference implementations") vary in how directly they reflect each source:
+> - **JDK** — test cases are explicit: the `hitEndTest`, `caretAtEndTest`, and `wordSearchTest` methods in `RegExTest.java` name specific patterns and inputs (e.g. `/^squidattack/` on `"squid"` / `"squack"`, `/^x?/m` on `"\r"`, `/\b/` on `"word1 word2 word3"`), which are reproduced directly.
+> - **Lucene** — test cases are derived: `TestRegExp.java` describes what each test method exercises (patterns like `[^y]*{1,2}`, `"(a)|".repeat(50000)`, and character sets σ/Σ/ῼ/ﬗ), but the specific assertions in the test suite here are our own translations of those properties.
+> - **RE2** — test cases are conceptual only: `tester.cc` and `exhaustive_tester.cc` implement a parametric consistency framework (NFA/DFA/backtracking agreement), not a fixed set of `(pattern, input, expected)` tuples. The RE2 rows below document semantic alignment rather than quoting specific test cases.
+
+### Apache Lucene (`TestRegExp.java`)
+
+Lucene implements partial matching via a deterministic finite automaton (DFA). Parity tests are **derived** from the described behaviour of each test method — not direct quotations of Lucene assertions.
+
+Lucene's automaton-based regex dialect **cannot express backreferences** (finite automata cannot represent them). `TestRegExp.java` contains no backreference tests.
+
+| Lucene test method | Property tested | This library |
+|---|---|---|
+| `testSmoke` | Basic grouping — `a(b+|c+)d` matches `abbbbbd`, `acd`; rejects `ad` | ✅ Covered — quantifiers, groups, disjunctions |
+| `testUnicodeAsciiInsensitiveFlags` | Unicode case folding — `σ`/`Σ`, `ῼ`, `ﬗ` | ✅ Covered — `i` + `u` flags delegate to JS Unicode case folding |
+| `testRepeatWithEmptyString` | Quantifiers over empty-matching sub-expressions — `[^y]*{1,2}` | ✅ Covered — `a*suffix`, `a?suffix`, `^[^y]*suffix` |
+| `testRegExpNoStackOverflow` | Deep nesting / stack safety — `(a)|` × 50 000 | ✅ Covered — wide alternation (× 1 000) and deeply nested groups (depth 100) |
+| `testCoreJavaParity` | 2 000 random expressions validated against `java.util.regex.Pattern` | ✅ Covered structurally — every prefix of every pattern is tested |
+| Backreferences | Not in scope — unsupported by the automaton dialect | See `PartialMatchRegExp` below |
+
+### Google RE2 (`tester.cc`, `exhaustive_tester.cc`)
+
+RE2 exposes partial matching via `UNANCHORED` mode (match anywhere in the string) versus `ANCHOR_BOTH` (full-string match). `tester.cc` and `exhaustive_tester.cc` implement a parametric testing framework that validates NFA, DFA, and backtracking engines against each other across exhaustively-generated patterns — there are **no fixed `(pattern, input, expected)` test cases to quote**. Parity is therefore assessed **conceptually** against RE2's semantics.
+
+RE2 **explicitly excludes backreferences by design**. From `re2.h`: *"backreferences and generalized assertions are not available"*. This is a deliberate trade-off to guarantee linear-time matching; there are therefore no backreference tests anywhere in RE2's test suite.
+
+| RE2 concept | This library |
+|---|---|
+| `UNANCHORED` — match substring anywhere | ✅ Use the pattern without `^`/`$` anchors |
+| `ANCHOR_START` — match from beginning | ✅ Use `^` anchor |
+| `ANCHOR_BOTH` — full-string match | ✅ Use `^…$` anchors |
+| First-match (NFA) vs longest-match (POSIX) semantics | ✅ ECMAScript / NFA first-match — `(a\|aa)\1` on `"aaaa"` yields `m[1]="a"`, not `"aa"` |
+| Capturing groups across anchoring modes | ✅ Covered — see groups tests |
+| Backreferences | Not in scope — excluded by design | See `PartialMatchRegExp` below |
+| Multi-engine consistency | N/A — JS has a single engine per runtime |
+
+### OpenJDK (`java.util.regex` — `RegExTest.java`)
+
+Java expresses partial matching through `Matcher.hitEnd()`, `Matcher.lookingAt()`, and `Matcher.find()`. Parity tests are **explicit**: the specific patterns and strings below are taken directly from named test methods in `RegExTest.java`.
+
+The JDK **does** support backreferences, and `RegExTest.java` includes `backRefTest()` (~line 2520) and `ciBackRefTest()` (~line 2568) for numeric backreferences with `find()`. However, **neither method combines backreferences with `hitEnd()` or any other partial-match concept** — they test full-match correctness only. There are no JDK tests for the behaviour of `hitEnd()` on patterns containing backreferences.
+
+| JDK test method / concept | Specific case | This library equivalent |
+|---|---|---|
+| `hitEndTest` (lines 545–588) | `/^squidattack/` on `"squid"` → `hitEnd=true` | `exec("squid")[0] === "squid"` (non-empty = prefix found) |
+| `hitEndTest` | `/^squidattack/` on `"squack"` → `hitEnd=false` | `exec("squack") === null` (anchored, diverges early) |
+| `hitEndTest` | `/^abc/` on `"ab"` → `hitEnd=true` | `exec("ab")[0] === "ab"` |
+| `hitEndTest` | `/^abc/` on `"ad"` → `hitEnd=false` | `exec("ad") === null` |
+| `hitEndTest` | `/catattack/` on `"attackattackattackcatatta"` → `hitEnd=true` | `exec(...)[0] !== ""` |
+| `caretAtEndTest` (lines 506–513) | `/^x?/m` on `"\r"` — successive `find()` calls | First match at index 0; second (after manual `lastIndex++`) at index 1 |
+| `wordSearchTest` (lines 483–503) | `/\b/` on `"word1 word2 word3"` with progressive `find(pos)` | `\bwor` with `g` flag and progressive `lastIndex` — finds matches at 0, 6, 12 |
+| `backRefTest` (~line 2520) | `(a*)bc\1`, `(abc)(def)\1` — full match via `find()` | Full match only; no partial-match equivalent in the JDK test |
+| `ciBackRefTest` (~line 2568) | Same patterns with `(?i)` case-insensitive flag | Full match only; no partial-match equivalent in the JDK test |
+| `Matcher.hitEnd()` | Semantic: did the engine exhaust input? | `exec(input)[0] !== ""` — non-empty result means valid prefix |
+| `Matcher.lookingAt()` | Prefix match from start | `exec` with `^` anchor |
+| `Matcher.matches()` | Full-string match | `exec` with `^…$` anchors |
+| `Matcher.find()` | Next substring match | `exec` on a `g`-flagged regex, advancing `lastIndex` |
+| `Matcher.find(pos)` | Match from a given position | Set `lastIndex` before calling `exec` |
+| `Matcher.requireEnd()` | More input could invalidate a current match | No direct equivalent; patterns ending with `$` or `\b` exhibit this — not explicitly exposed |
+
+### Summary
+
+| Feature | Lucene | RE2 | JDK | This library |
+|---|:---:|:---:|:---:|:---:|
+| Literal prefix matching | ✅ | ✅ | ✅ | ✅ |
+| Character classes | ✅ | ✅ | ✅ | ✅ |
+| Quantifiers (including zero-match) | ✅ | ✅ | ✅ | ✅ |
+| Disjunctions | ✅ | ✅ | ✅ | ✅ |
+| Groups (capturing, non-capturing, named) | ✅ | ✅ | ✅ | ✅ |
+| Lookahead / lookbehind | — | ✅ | ✅ | ✅ |
+| Unicode case folding | ✅ | ✅ | ✅ | ✅ (`i`+`u` flags) |
+| Deep nesting / stack safety | ✅ | ✅ | ✅ | ✅ |
+| Anchored full match | ✅ | ✅ | ✅ (`matches()`) | ✅ (`^…$`) |
+| Unanchored substring match | ✅ | ✅ | ✅ (`find()`) | ✅ (no anchor) |
+| hitEnd() / prefix-only match | — | — | ✅ | ✅ (non-empty exec result) |
+| requireEnd() | — | — | ✅ | ⚠️ Not exposed |
+| Backreference partial matching | ❌ unsupported dialect | ❌ excluded by design | ⚠️ full match only (`backRefTest`) | ✅ (`PartialMatchRegExp` class) |
+| Multi-engine consistency | — | ✅ | — | N/A |
+
 ## Related projects
 
-| Project                                                                    | Description                                                                                                                                                                          |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [`incr-regex-package`](https://www.npmjs.com/package/incr-regex-package)   | Incremental regex matcher                                                                                                                                                            |
-| [`dfa`](https://github.com/foliojs/dfa)                                    | Compiles a regular expression like syntax to fast deterministic finite automata, which could be used to partial match?                                                               |
-| [`refa`](https://github.com/RunDevelopment/refa)                           | Can [convert regular expressions to an Abstract Syntax Tree](https://rundevelopment.github.io/refa/docs/latest/classes/JS.Parser.html), which might afford partial-match capability? |
-| [`@eslint-community/regexpp`](https://github.com/eslint-community/regexpp) | A regular expression parser for ECMAScript with AST generation and visitor implementation                                                                                            |
-| [`Regex+`](https://www.npmjs.com/package/regex)                            | template literal, transforming native regular expressions                                                                                                                            |
-| [`Awesome Regex`](https://github.com/slevithan/awesome-regex)              | Curated list of tools, tutorials, libraries, and other resources, covering all major regex flavours                                                                                  |
+| Project                                                                                     | Description                                                                                                                                                                          |
+| ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`incr-regex-package`](https://www.npmjs.com/package/incr-regex-package)                    | Incremental regex matcher                                                                                                                                                            |
+| [`dfa`](https://github.com/foliojs/dfa)                                                     | Compiles a regular expression like syntax to fast deterministic finite automata, which could be used to partial match?                                                               |
+| [`refa`](https://github.com/RunDevelopment/refa)                                            | Can [convert regular expressions to an Abstract Syntax Tree](https://rundevelopment.github.io/refa/docs/latest/classes/JS.Parser.html), which might afford partial-match capability? |
+| [`@eslint-community/regexpp`](https://github.com/eslint-community/regexpp)                  | A regular expression parser for ECMAScript with AST generation and visitor implementation                                                                                            |
+| [`Regex+`](https://www.npmjs.com/package/regex)                                             | template literal, transforming native regular expressions                                                                                                                            |
+| [`Awesome Regex`](https://github.com/slevithan/awesome-regex)                               | Curated list of tools, tutorials, libraries, and other resources, covering all major regex flavours                                                                                  |
+| [`replace-content-transformer`](https://github.com/TomStrepsil/replace-content-transformer) | A toolkit for stream content replacement, underpinned by `regex-partial-match`                                                                                                                                                                                 |

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ The JDK **does** support backreferences, and `RegExTest.java` includes `backRefT
 | Unanchored substring match | ✅ | ✅ | ✅ (`find()`) | ✅ (no anchor) |
 | hitEnd() / prefix-only match | — | — | ✅ | ✅ (non-empty exec result) |
 | requireEnd() | — | — | ✅ | ⚠️ Not exposed |
-| Backreference partial matching | ❌ unsupported dialect | ❌ excluded by design | ⚠️ full match only (`backRefTest`) | ✅ (`PartialMatchRegExp` class) |
+| Backreference partial matching | ❌ unsupported dialect | ❌ excluded by design | ⚠️ full match only (`backRefTest`) | ❌ cannot partially match (atomic) |
 | Multi-engine consistency | — | ✅ | — | N/A |
 
 ## Related projects

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ The following regex features are **not currently supported**:
 
 ## Browser Compatibility
 
-The library is compiled to **ES5** for broad compatibility with older browsers and JavaScript environments. However, certain regular expression features naturally require ES2015+ support:
+The library requires **ES2015** (ECMAScript 6) — the minimum JavaScript version that supports native extension of built-in types such as `RegExp`, which `PartialMatchRegExp` relies on to override `exec()`. Additionally, certain regular expression features require newer environments:
 
-- [**Unicode escapes**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape) (`\u{...}`) - ES2015+
+- [**Unicode escapes**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape) (`\u{...}`)
 - [**Unicode property escapes**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape) (`\p{...}`, `\P{...}`) - ES2018+
 - [**Lookbehind assertions**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion) (`(?<=...)`, `(?<!...)`) - ES2018+
 - [**Named capturing groups**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group) (`(?<name>...)`) - ES2018+
@@ -105,7 +105,10 @@ The library is compiled to **ES5** for broad compatibility with older browsers a
 
 ### [`.test()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) and empty-input behaviour
 
-The partial transform produces a pattern that can match an empty string at the end of input (via the `|$` sentinel). `PartialMatchRegExp` suppresses these sentinel matches — an empty match at `index === input.length` is treated as `null`, so `test()` and `exec()` behave as expected for non-matching strings:
+The partial transform produces a pattern that can match an empty string at the end of input (via the `|$` sentinel). `PartialMatchRegExp` suppresses these sentinel matches — but only when the original pattern would not itself match at that position. This means:
+
+- inputs that the pattern genuinely matches (including patterns that match at end-of-input like `/$/`) return `true`
+- inputs where the sentinel fired only because the pattern ran off the end return `false`
 
 ```js
 const re = new PartialMatchRegExp(/^foo/);
@@ -113,6 +116,8 @@ re.test("bar"); // false — cannot match
 re.test("fo");  // true  — valid prefix
 re.test("foo"); // true  — full match
 re.test("");    // false — pattern does not accept empty string
+
+new PartialMatchRegExp(/$/).test("abc"); // true — $ genuinely matches end-of-input
 ```
 
 `test("")` reflects whether the original pattern matches the empty string. Patterns like `/^a*/` or `/^$/` do accept `""`, so `test("")` returns `true` for those. Patterns that require at least one character return `false`.
@@ -287,7 +292,7 @@ Contributions are welcome! Please open an issue or pull request on [GitHub](http
 
 Several widely-used regex libraries offer native partial-match support. This section maps their concepts and test cases to this library's behaviour.
 
-> **Provenance note:** The parity tests added in `src/index.test.ts` ("parity with reference implementations") vary in how directly they reflect each source:
+> **Provenance note:** The parity tests added in `src/createPartialMatchRegex.test.ts` ("parity with reference implementations") vary in how directly they reflect each source:
 > - **JDK** — test cases are explicit: the `hitEndTest`, `caretAtEndTest`, and `wordSearchTest` methods in `RegExTest.java` name specific patterns and inputs (e.g. `/^squidattack/` on `"squid"` / `"squack"`, `/^x?/m` on `"\r"`, `/\b/` on `"word1 word2 word3"`), which are reproduced directly.
 > - **Lucene** — test cases are derived: `TestRegExp.java` describes what each test method exercises (patterns like `[^y]*{1,2}`, `"(a)|".repeat(50000)`, and character sets σ/Σ/ῼ/ﬗ), but the specific assertions in the test suite here are our own translations of those properties.
 > - **RE2** — test cases are conceptual only: `tester.cc` and `exhaustive_tester.cc` implement a parametric consistency framework (NFA/DFA/backtracking agreement), not a fixed set of `(pattern, input, expected)` tuples. The RE2 rows below document semantic alignment rather than quoting specific test cases.

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -7,9 +7,6 @@ Performance benchmarks for `regex-partial-match`, built with [mitata](https://gi
 ```sh
 # Pretty-print results to terminal
 npm run bench --workspace=benchmarking
-
-# JSON output (used by CI)
-npm run bench:ci --workspace=benchmarking
 ```
 
 ## Scenarios
@@ -58,7 +55,7 @@ The baseline is only updated on merges to `main` — PR runs read but do not wri
 
 ## Output format
 
-`scripts/to-action-format.ts` converts mitata's JSON output to the `github-action-benchmark` schema:
+`../.github/scripts/to-action-format.ts` converts mitata's JSON output to the `github-action-benchmark` schema:
 
 ```json
 [

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -1,0 +1,75 @@
+# Benchmarks
+
+Performance benchmarks for `regexp-partial-match`, built with [mitata](https://github.com/nicolo-ribaudo/mitata).
+
+## Running locally
+
+```sh
+# Pretty-print results to terminal
+npm run bench --workspace=benchmarking
+
+# JSON output (used by CI)
+npm run bench:ci --workspace=benchmarking
+```
+
+## Scenarios
+
+### 1. Dispatch overhead (`dispatch-overhead.bench.ts`)
+
+Isolates the cost of `PartialMatchRegExp`'s `exec()` override. All three candidates run the same underlying partial pattern against the same input — the only variable is whether a JavaScript wrapper sits in the call chain:
+
+| Candidate | Notes |
+|---|---|
+| Native `RegExp.exec` | Baseline — no partial transform, no override |
+| `createPartialMatchRegex()` result | Partial source baked into a plain `RegExp` — no class overhead |
+| `PartialMatchRegExp.exec` | Partial source via the class override |
+
+Two input cases are measured: a full match, and a partial input that returns `null` on the native regex.
+
+### 2. Hot loop (`hot-loop.bench.ts`)
+
+V8's string-method fast path checks whether `exec()` is overridden on every iteration of a global match loop. This scenario quantifies that cost at realistic scale (~7 KB / ~700 words).
+
+Two loop styles are compared against their native equivalents:
+
+- **Manual `exec` loop** (`exec` / `lastIndex` cycle) — directly exercises the override check each iteration.
+- **`String.prototype.matchAll`** — after TC39 species removal, `matchAll` copies the regex internally, which may suppress the override check entirely. Benchmarking both reveals whether the overhead actually materialises.
+
+### 3. Keystroke simulation (`keystroke.bench.ts`)
+
+Models a user typing character-by-character into a validated input field. Each prefix of the full input is tested once — this is the primary real-world use case for partial matching.
+
+Two patterns are exercised:
+
+| Pattern | Example input | Length |
+|---|---|---|
+| E.164-style phone number | `+1 (555) 123-4567` | 18 chars |
+| ISO 8601 date | `2024-12-31` | 10 chars |
+
+Each group compares native `test` (always returns `false` for incomplete input), a plain partial `RegExp`, and `PartialMatchRegExp`.
+
+## CI integration
+
+The workflow at [`.github/workflows/benchmark.yml`](../.github/workflows/benchmark.yml) runs on every push to `main` and on pull requests targeting `main`.
+
+Results are stored and compared by [`benchmark-action/github-action-benchmark`](https://github.com/benchmark-action/github-action-benchmark) using the `customSmallerIsBetter` tool. A regression alert comment is posted on the PR if any benchmark regresses beyond 150% of the stored baseline (a loose threshold to account for CI runner noise).
+
+The baseline is only updated on merges to `main` — PR runs read but do not write the baseline.
+
+## Output format
+
+`scripts/to-action-format.ts` converts mitata's JSON output to the `github-action-benchmark` schema:
+
+```json
+[
+  {
+    "name": "<group> — <bench name>",
+    "value": 123.45,
+    "unit": "ns/iter",
+    "range": "± 1.23",
+    "extra": "min: 120ns  p75: 125ns  p99: 140ns"
+  }
+]
+```
+
+All timings are normalised to nanoseconds per iteration from mitata's internal second representation.

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -1,6 +1,6 @@
 # Benchmarks
 
-Performance benchmarks for `regexp-partial-match`, built with [mitata](https://github.com/nicolo-ribaudo/mitata).
+Performance benchmarks for `regex-partial-match`, built with [mitata](https://github.com/nicolo-ribaudo/mitata).
 
 ## Running locally
 

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -55,7 +55,7 @@ The baseline is only updated on merges to `main` — PR runs read but do not wri
 
 ## Output format
 
-`../.github/scripts/to-action-format.ts` converts mitata's JSON output to the `github-action-benchmark` schema:
+`../.github/scripts/mitata-to-action-format.ts` converts mitata's JSON output to the `github-action-benchmark` schema:
 
 ```json
 [
@@ -69,4 +69,4 @@ The baseline is only updated on merges to `main` — PR runs read but do not wri
 ]
 ```
 
-All timings are normalised to nanoseconds per iteration from mitata's internal second representation.
+Mitata v1's JSON stats are already in nanoseconds per iteration; the converter passes them through as `ns/iter`.

--- a/benchmarking/package.json
+++ b/benchmarking/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "regex-partial-match-benchmarks",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "bench": "tsx src/run.ts",
+    "bench:ci": "tsx src/run.ts --json | tsx scripts/to-action-format.ts > results.json"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.3",
+    "mitata": "^1.0.0",
+    "tsx": "^4.19.0"
+  }
+}

--- a/benchmarking/package.json
+++ b/benchmarking/package.json
@@ -3,8 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "bench": "tsx src/run.ts",
-    "bench:ci": "tsx src/run.ts --json | tsx scripts/to-action-format.ts > results.json"
+    "bench": "tsx src/run.ts"
   },
   "devDependencies": {
     "@types/node": "^25.9.3",

--- a/benchmarking/scripts/to-action-format.ts
+++ b/benchmarking/scripts/to-action-format.ts
@@ -1,0 +1,69 @@
+/**
+ * Converts mitata JSON output (from `tsx src/run.ts --json`) to the
+ * github-action-benchmark customSmallerIsBetter format.
+ *
+ * Input (stdin): mitata run() result — either an array of benchmarks or
+ *   { benchmarks: [...] } depending on mitata version.
+ *
+ * Output (stdout): JSON array of:
+ *   { name: string, value: number, unit: "ns/iter", range: string, extra: string }
+ *
+ * mitata reports time in seconds internally. This script normalises to ns/iter.
+ * If your mitata version reports in nanoseconds (value > 1 for typical bench),
+ * set SEC_TO_NS = 1 below.
+ *
+ * Usage:
+ *   tsx src/run.ts --json | tsx scripts/to-action-format.ts > results.json
+ */
+
+const SEC_TO_NS = 1e9;
+
+interface MitataStats {
+  avg: number;
+  min: number;
+  max: number;
+  p75: number;
+  p99: number;
+  stddev: number;
+}
+
+interface MitataBenchmark {
+  name: string;
+  group?: string;
+  stats?: MitataStats;
+}
+
+interface ActionEntry {
+  name: string;
+  value: number;
+  unit: string;
+  range: string;
+  extra: string;
+}
+
+const chunks: string[] = [];
+for await (const chunk of process.stdin) {
+  chunks.push(chunk as string);
+}
+const raw: unknown = JSON.parse(chunks.join(""));
+
+const benchmarks: MitataBenchmark[] = Array.isArray(raw)
+  ? (raw as MitataBenchmark[])
+  : ((raw as { benchmarks?: MitataBenchmark[] }).benchmarks ?? []);
+
+const output: ActionEntry[] = benchmarks
+  .filter((b): b is MitataBenchmark & { stats: MitataStats } => b.stats != null)
+  .map((b) => {
+    const label = b.group ? `${b.group} — ${b.name}` : b.name;
+    const toNs = (s: number) => +(s * SEC_TO_NS).toFixed(2);
+    const ns = (s: number) => toNs(s).toString();
+    return {
+      name: label,
+      value: toNs(b.stats.avg),
+      unit: "ns/iter",
+      range: `± ${ns(b.stats.stddev)}`,
+      extra: `min: ${ns(b.stats.min)}ns  p75: ${ns(b.stats.p75)}ns  p99: ${ns(b.stats.p99)}ns`,
+    };
+  });
+
+process.stdout.write(JSON.stringify(output, null, 2) + "\n");

--- a/benchmarking/scripts/to-action-format.ts
+++ b/benchmarking/scripts/to-action-format.ts
@@ -41,11 +41,13 @@ interface ActionEntry {
   extra: string;
 }
 
-const chunks: string[] = [];
+process.stdin.setEncoding("utf8");
+
+let input = "";
 for await (const chunk of process.stdin) {
-  chunks.push(chunk as string);
+  input += chunk;
 }
-const raw: unknown = JSON.parse(chunks.join(""));
+const raw: unknown = JSON.parse(input);
 
 const benchmarks: MitataBenchmark[] = Array.isArray(raw)
   ? (raw as MitataBenchmark[])

--- a/benchmarking/src/dispatch-overhead.bench.ts
+++ b/benchmarking/src/dispatch-overhead.bench.ts
@@ -1,0 +1,37 @@
+/**
+ * Scenario 1: exec() override dispatch cost
+ *
+ * Isolates the JavaScript wrapper overhead introduced by PartialMatchRegExp's
+ * exec() override. All three candidates run the same underlying partial pattern 
+ * — the only variable is whether a JS override function sits in the call chain.
+ *
+ * Baselines:
+ *   - native RegExp.exec          — no partial transform, no override
+ *   - createPartialMatchRegex()   — partial source baked in, plain RegExp, no override
+ *   - PartialMatchRegExp.exec     — partial source via override
+ */
+
+import { bench, group } from "mitata";
+import createPartialMatchRegex from "../../src/createPartialMatchRegex.ts";
+import PartialMatchRegExp from "../../src/partialMatchRegExp.ts";
+
+const pattern = /^[a-z]+(?:\s\w+){1,3}/;
+
+const native = pattern;
+const plainPartial = createPartialMatchRegex(pattern);
+const classPartial = new PartialMatchRegExp(pattern);
+
+const fullMatchInput = "hello world foo";
+const partialInput = "hello wor";
+
+group("dispatch overhead — full match input", () => {
+  bench("native RegExp.exec", () => native.exec(fullMatchInput));
+  bench("plain partial RegExp (no class wrapper)", () => plainPartial.exec(fullMatchInput));
+  bench("PartialMatchRegExp.exec", () => classPartial.exec(fullMatchInput));
+});
+
+group("dispatch overhead — partial input (returns null on native)", () => {
+  bench("native RegExp.exec", () => native.exec(partialInput));
+  bench("plain partial RegExp (no class wrapper)", () => plainPartial.exec(partialInput));
+  bench("PartialMatchRegExp.exec", () => classPartial.exec(partialInput));
+});

--- a/benchmarking/src/hot-loop.bench.ts
+++ b/benchmarking/src/hot-loop.bench.ts
@@ -1,0 +1,46 @@
+/**
+ * Scenario 2: hot loop — global exec over a large string
+ *
+ * V8's string method fast path checks whether exec() is overridden on every
+ * iteration of a global match loop. This scenario quantifies that cost at
+ * realistic scale (~700 words, ~4 KB).
+ *
+ * Two loop styles are measured:
+ *   - manual exec loop (exec/lastIndex cycle) — directly exercises the override check
+ *   - String.prototype.matchAll              — exercises species + iterator overhead
+ *
+ * Note: matchAll internally copies the regex. After TC39 species removal,
+ * that copy is a plain RegExp regardless of the input type, so the exec
+ * override may NOT fire in the matchAll path. Benchmarking both reveals this.
+ */
+
+import { bench, group } from "mitata";
+import PartialMatchRegExp from "../../src/partialMatchRegExp.ts";
+
+const text = (
+  "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod " +
+  "tempor incididunt ut labore et dolore magna aliqua ut enim ad minim "
+).repeat(50).trim(); // ~7 KB, ~700 words
+
+const nativeGlobal = /\b\w+\b/g;
+const partialGlobal = new PartialMatchRegExp(/\b\w+\b/, "g");
+
+group("hot loop — manual global exec (~700 matches)", () => {
+  bench("native RegExp (global exec loop)", () => {
+    nativeGlobal.lastIndex = 0;
+    while (nativeGlobal.exec(text) !== null) {}
+  });
+  bench("PartialMatchRegExp (global exec loop)", () => {
+    partialGlobal.lastIndex = 0;
+    while (partialGlobal.exec(text) !== null) {}
+  });
+});
+
+group("hot loop — String.prototype.matchAll (~700 matches)", () => {
+  bench("native matchAll", () => {
+    for (const m of text.matchAll(/\b\w+\b/g)) void m;
+  });
+  bench("PartialMatchRegExp matchAll", () => {
+    for (const m of text.matchAll(new PartialMatchRegExp(/\b\w+\b/, "g"))) void m;
+  });
+});

--- a/benchmarking/src/keystroke.bench.ts
+++ b/benchmarking/src/keystroke.bench.ts
@@ -1,0 +1,64 @@
+/**
+ * Scenario 3: keystroke simulation
+ *
+ * Models a user typing character-by-character into a validated input field.
+ * Each prefix is exec'd once — this is the primary real-world use case for
+ * partial matching.
+ *
+ * Compares:
+ *   - native exec (no partial, returns null for incomplete input)
+ *   - createPartialMatchRegex result (plain RegExp, no class overhead)
+ *   - PartialMatchRegExp.exec
+ *
+ * Two patterns exercise different prefix lengths:
+ *   - phone number: 18 chars (+1 (555) 123-4567)
+ *   - ISO date:     10 chars (2024-12-31)
+ */
+
+import { bench, group } from "mitata";
+import createPartialMatchRegex from "../../src/createPartialMatchRegex.ts";
+import PartialMatchRegExp from "../../src/partialMatchRegExp.ts";
+
+// E.164-style phone number
+const phonePattern = /^\+?1?\s?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/;
+const phoneInput = "+1 (555) 123-4567";
+const phonePrefixes = Array.from({ length: phoneInput.length }, (_, i) =>
+  phoneInput.slice(0, i + 1)
+);
+const nativePhone = phonePattern;
+const plainPartialPhone = createPartialMatchRegex(phonePattern);
+const classPartialPhone = new PartialMatchRegExp(phonePattern);
+
+// ISO 8601 date
+const datePattern = /^\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])$/;
+const dateInput = "2024-12-31";
+const datePrefixes = Array.from({ length: dateInput.length }, (_, i) =>
+  dateInput.slice(0, i + 1)
+);
+const nativeDate = datePattern;
+const plainPartialDate = createPartialMatchRegex(datePattern);
+const classPartialDate = new PartialMatchRegExp(datePattern);
+
+group("keystroke simulation — phone number (18 chars)", () => {
+  bench("native exec per keystroke (always null)", () => {
+    for (const s of phonePrefixes) nativePhone.test(s);
+  });
+  bench("plain partial RegExp.test per keystroke", () => {
+    for (const s of phonePrefixes) plainPartialPhone.test(s);
+  });
+  bench("PartialMatchRegExp.test per keystroke", () => {
+    for (const s of phonePrefixes) classPartialPhone.test(s);
+  });
+});
+
+group("keystroke simulation — ISO date (10 chars)", () => {
+  bench("native exec per keystroke (always null)", () => {
+    for (const s of datePrefixes) nativeDate.test(s);
+  });
+  bench("plain partial RegExp.test per keystroke", () => {
+    for (const s of datePrefixes) plainPartialDate.test(s);
+  });
+  bench("PartialMatchRegExp.test per keystroke", () => {
+    for (const s of datePrefixes) classPartialDate.test(s);
+  });
+});

--- a/benchmarking/src/keystroke.bench.ts
+++ b/benchmarking/src/keystroke.bench.ts
@@ -52,7 +52,7 @@ group("keystroke simulation — phone number (18 chars)", () => {
 });
 
 group("keystroke simulation — ISO date (10 chars)", () => {
-  bench("native exec per keystroke (always null)", () => {
+  bench("native RegExp.test per keystroke (fails until full input)", () => {
     for (const s of datePrefixes) nativeDate.test(s);
   });
   bench("plain partial RegExp.test per keystroke", () => {

--- a/benchmarking/src/keystroke.bench.ts
+++ b/benchmarking/src/keystroke.bench.ts
@@ -40,7 +40,7 @@ const plainPartialDate = createPartialMatchRegex(datePattern);
 const classPartialDate = new PartialMatchRegExp(datePattern);
 
 group("keystroke simulation — phone number (18 chars)", () => {
-  bench("native exec per keystroke (always null)", () => {
+  bench("native RegExp.test per keystroke (fails until full input)", () => {
     for (const s of phonePrefixes) nativePhone.test(s);
   });
   bench("plain partial RegExp.test per keystroke", () => {

--- a/benchmarking/src/run.ts
+++ b/benchmarking/src/run.ts
@@ -9,10 +9,9 @@
  * The --json output is intended to be piped to scripts/to-action-format.ts
  * for the github-action-benchmark customSmallerIsBetter format.
  *
- * mitata JSON format note: run() returns an object whose shape varies between
- * minor versions. The converter handles the two common shapes:
- *   - array of benchmark results (v0.x)
- *   - { benchmarks: [...] } (v1.x)
+ * mitata v1.x json format: run() with { format: { json: {...} } } writes the
+ * result to stdout via console.log and returns it. The converter handles the
+ * { benchmarks: [...] } shape that mitata v1.x produces.
  */
 
 import "./dispatch-overhead.bench.ts";
@@ -22,14 +21,11 @@ import { run } from "mitata";
 
 const isJson = process.argv.includes("--json");
 
-const results = await run({
+// When --json: mitata's json format writes the result to stdout itself via
+// console.log. Do not also call process.stdout.write — that would produce two
+// concatenated JSON objects and break the downstream parser.
+// samples:false drops raw timing arrays from the output; we only need summary stats.
+await run({
   colors: !isJson,
-  // mitata v1.x: suppress table when outputting JSON
-  // If your version doesn't support this option, redirect stderr:
-  //   tsx src/run.ts --json 2>/dev/null | tsx scripts/to-action-format.ts
-  ...(isJson ? { format: "json" } : {}),
+  ...(isJson ? { format: { json: { samples: false } } } : {}),
 });
-
-if (isJson) {
-  process.stdout.write(JSON.stringify(results) + "\n");
-}

--- a/benchmarking/src/run.ts
+++ b/benchmarking/src/run.ts
@@ -6,7 +6,7 @@
  *   tsx src/run.ts              — pretty-print results to terminal
  *   tsx src/run.ts --json       — output mitata JSON to stdout (no table)
  *
- * The --json output is intended to be piped to scripts/to-action-format.ts
+ * The --json output is intended to be piped to ../.github/scripts/mitata-to-action-format.ts
  * for the github-action-benchmark customSmallerIsBetter format.
  *
  * mitata v1.x json format: run() with { format: { json: {...} } } writes the

--- a/benchmarking/src/run.ts
+++ b/benchmarking/src/run.ts
@@ -1,0 +1,35 @@
+/**
+ * Benchmark entry point. Imports all scenario files (which register their
+ * bench/group calls globally in mitata) then calls run().
+ *
+ * Usage:
+ *   tsx src/run.ts              — pretty-print results to terminal
+ *   tsx src/run.ts --json       — output mitata JSON to stdout (no table)
+ *
+ * The --json output is intended to be piped to scripts/to-action-format.ts
+ * for the github-action-benchmark customSmallerIsBetter format.
+ *
+ * mitata JSON format note: run() returns an object whose shape varies between
+ * minor versions. The converter handles the two common shapes:
+ *   - array of benchmark results (v0.x)
+ *   - { benchmarks: [...] } (v1.x)
+ */
+
+import "./dispatch-overhead.bench.ts";
+import "./hot-loop.bench.ts";
+import "./keystroke.bench.ts";
+import { run } from "mitata";
+
+const isJson = process.argv.includes("--json");
+
+const results = await run({
+  colors: !isJson,
+  // mitata v1.x: suppress table when outputting JSON
+  // If your version doesn't support this option, redirect stderr:
+  //   tsx src/run.ts --json 2>/dev/null | tsx scripts/to-action-format.ts
+  ...(isJson ? { format: "json" } : {}),
+});
+
+if (isJson) {
+  process.stdout.write(JSON.stringify(results) + "\n");
+}

--- a/benchmarking/tsconfig.json
+++ b/benchmarking/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "moduleDetection": "force",
+    "noEmit": true,
+    "rootDir": "..",
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "scripts/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved to [`slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) from [`substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring), marginally more compact and more commonly used
 - Updated `README.md` to clarify "How It Works", and consistent spelling of "behaviour" (🇬🇧)
 - **Breaking:** Removed `createPartialMatchRegexp` method as default export
+- Upgraded `actions/checkout` to [v7](https://github.com/actions/checkout/tree/v7)
 
 ### Added
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `setup-node` action to ensure npm version is honoured in pipeline
 - Fixed errant CHANGELOG version for v[0.1.8](#018---2025-12-08)
 - Added missing tests for wildcard expressions
+- Fixed test with UTF-16 code units to assert they match independently, properly
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pinned `package.json->devEngines->packageManager` to exact version, since corepack doesn't support semver ranges, and added a deterministic hash as a security best practice
 - Added a `setup-node` action to ensure npm version is honoured in pipeline
+- Fixed errant CHANGELOG version for v[0.1.8](#018---2025-12-08)
+- Added missing tests for wildcard expressions
+
+### Changed
+
+- Moved to [`slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) from [`substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring), marginally more compact and more commonly used
+- Updated `README.md` to clarify "How It Works", and consistent spelling of "behaviour" (🇬🇧)
+- **Breaking:** Removed `createPartialMatchRegexp` method as default export
+
+### Added
+
+- `PartialMatchRegExp` class as default export, to ensure `.test()` doesn't always return true based on matching a non-terminal (`^`) end of pattern
+- Parity tests aligned with external partial-match reference implementations:
+  - **Apache Lucene** (`TestRegExp.java`): deep nesting / stack safety, quantifiers over empty-matching sub-expressions, Unicode case folding (σ/Σ, ῼ)
+  - **JDK** (`java.util.regex` / `RegExTest.java`): `hitEnd()` semantic equivalence (non-empty exec result = prefix found), CRLF boundary in multiline mode (`caretAtEndTest`), progressive `find(pos)` via `lastIndex` (`wordSearchTest`)
+- `README.md` section "Compatibility with other partial-match implementations" mapping Lucene, RE2, and JDK concepts to this library's API, including a cross-reference parity table
+- "benchmarking" workspace, validating `exec()` overhead
 
 ## [0.4.0] - 2026-06-13
 
@@ -147,7 +164,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed import statement for usage examples, for brevity / consistency
 
-## [0.1.7] - 2025-12-08
+## [0.1.8] - 2025-12-08
 
 ### Added
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** Raised minimum JavaScript environment from ES5 to ES2015 (ECMAScript 6) — the minimum version supporting native extension of built-in types such as `RegExp`, which `PartialMatchRegExp` relies on to override `exec()`
 - **Breaking:** Removed `createPartialMatchRegex` method as default export
 - Moved to [`slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) from [`substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring), marginally more compact and more commonly used
 - Updated `README.md` to clarify "How It Works", and consistent spelling of "behaviour" (🇬🇧)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved to [`slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) from [`substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring), marginally more compact and more commonly used
 - Updated `README.md` to clarify "How It Works", and consistent spelling of "behaviour" (🇬🇧)
 - Upgraded `actions/checkout` to [v7](https://github.com/actions/checkout/tree/v7)
+- Upgraded `actions/github-script` to [v9](https://github.com/actions/github-script/tree/v9)
 
 ### Added
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,12 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moved to [`slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) from [`substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring), marginally more compact and more commonly used
 - Updated `README.md` to clarify "How It Works", and consistent spelling of "behaviour" (🇬🇧)
-- **Breaking:** Removed `createPartialMatchRegexp` method as default export
+- **Breaking:** Removed `createPartialMatchRegex` method as default export
 
 ### Added
 
-- `PartialMatchRegExp` class as default export, to ensure `.test()` doesn't always return true based on matching a non-terminal (`^`) end of pattern
-- Parity tests aligned with external partial-match reference implementations:
+- `PartialMatchRegExp` class as default export, to ensure `.test()` doesn't always return true based on matching the end-of-input sentinel (`$`)
   - **Apache Lucene** (`TestRegExp.java`): deep nesting / stack safety, quantifiers over empty-matching sub-expressions, Unicode case folding (σ/Σ, ῼ)
   - **JDK** (`java.util.regex` / `RegExTest.java`): `hitEnd()` semantic equivalence (non-empty exec result = prefix found), CRLF boundary in multiline mode (`caretAtEndTest`), progressive `find(pos)` via `lastIndex` (`wordSearchTest`)
 - `README.md` section "Compatibility with other partial-match implementations" mapping Lucene, RE2, and JDK concepts to this library's API, including a cross-reference parity table

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,7 +25,12 @@ Please be respectful and constructive in all interactions. We aim to maintain a 
    ```bash
    git remote add upstream https://github.com/TomStrepsil/regex-partial-match.git
    ```
-4. **Install dependencies**:
+4. **Enable corepack**:
+   ```bash
+   corepack enable npm
+   corepack install
+   ```
+5. **Install dependencies**:
    ```bash
    npm install
    ```
@@ -132,10 +137,11 @@ git push origin {issue}_your-feature-name
 Tests are located in `test/` directory. Follow these patterns:
 
 ```typescript
+import PartialMatchRegExp from "../src/partialMatchRegExp.ts";
+
 describe("feature name", () => {
   it("should do something specific", () => {
-    const input = /pattern/;
-    const partial = createPartialMatchRegex(input);
+    const partial = new PartialMatchRegExp(/pattern/);
 
     expect(partial.test("partial")).toBe(true);
   });

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -134,7 +134,7 @@ git push origin {issue}_your-feature-name
 
 ### Writing Tests
 
-Tests are located in `test/` directory. Follow these patterns:
+Tests are colocated next to the sourcecode in `/src`. Follow these patterns:
 
 ```typescript
 import PartialMatchRegExp from "../src/partialMatchRegExp.ts";

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -134,7 +134,7 @@ git push origin {issue}_your-feature-name
 
 ### Writing Tests
 
-Tests are colocated next to the sourcecode in `/src`. Follow these patterns:
+Tests are colocated next to the source code in `src/`. Follow these patterns:
 
 ```typescript
 import PartialMatchRegExp from "../src/partialMatchRegExp.ts";

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -23,7 +23,7 @@ export default [
     files: ["**/*.ts"],
     languageOptions: {
       parserOptions: {
-        project: "./tsconfig.json"
+        project: ["./tsconfig.json", "./benchmarking/tsconfig.json"]
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,12 @@
         "@eslint/js": "^9.17.0",
         "@eslint/markdown": "^7.5.1",
         "@types/node": "^25.9.3",
-        "@typescript-eslint/eslint-plugin": "^8.61.1",
         "eslint": "^9.17.0",
         "jiti": "^2.6.1",
         "lint-staged": "^15.2.11",
         "simple-git-hooks": "^2.12.1",
         "typescript": "^6.0.3",
+        "typescript-eslint": "^8.61.1",
         "vitest": "^4.0.15"
       }
     },
@@ -1185,7 +1185,6 @@
       "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.1",
         "@typescript-eslint/types": "8.61.1",
@@ -4662,6 +4661,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
+      "integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.61.1",
+        "@typescript-eslint/parser": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,13 @@
       "devDependencies": {
         "@eslint/js": "^9.17.0",
         "@eslint/markdown": "^7.5.1",
+        "@types/node": "^25.9.3",
+        "@typescript-eslint/eslint-plugin": "^8.61.1",
         "eslint": "^9.17.0",
         "jiti": "^2.6.1",
         "lint-staged": "^15.2.11",
         "simple-git-hooks": "^2.12.1",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.61.1",
         "vitest": "^4.0.15"
       }
     },
@@ -1184,6 +1185,7 @@
       "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.1",
         "@typescript-eslint/types": "8.61.1",
@@ -4660,30 +4662,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/typescript-eslint": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
-      "integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.61.1",
-        "@typescript-eslint/parser": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1",
-        "@typescript-eslint/utils": "8.61.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "regex-partial-match",
       "version": "0.4.0",
       "license": "ISC",
+      "workspaces": [
+        "benchmarking"
+      ],
       "devDependencies": {
         "@eslint/js": "^9.17.0",
         "@eslint/markdown": "^7.5.1",
@@ -15,9 +18,17 @@
         "jiti": "^2.6.1",
         "lint-staged": "^15.2.11",
         "simple-git-hooks": "^2.12.1",
-        "typescript": "^5.9.3",
-        "typescript-eslint": "^8.18.1",
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.61.1",
         "vitest": "^4.0.15"
+      }
+    },
+    "benchmarking": {
+      "name": "regex-partial-match-benchmarks",
+      "devDependencies": {
+        "@types/node": "^25.9.3",
+        "mitata": "^1.0.0",
+        "tsx": "^4.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -54,10 +65,452 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -669,6 +1122,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -677,21 +1140,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.48.1.tgz",
-      "integrity": "sha512-X63hI1bxl5ohelzr0LY5coufyl0LJNthld+abwxpCoo6Gq+hSqhKwci7MUWkXo67mzgUK6YFByhmaHmUcuBJmA==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
+      "integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.48.1",
-        "@typescript-eslint/type-utils": "8.48.1",
-        "@typescript-eslint/utils": "8.48.1",
-        "@typescript-eslint/visitor-keys": "8.48.1",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/type-utils": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -701,9 +1163,9 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.48.1",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "@typescript-eslint/parser": "^8.61.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -717,17 +1179,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.48.1.tgz",
-      "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
+      "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.48.1",
-        "@typescript-eslint/types": "8.48.1",
-        "@typescript-eslint/typescript-estree": "8.48.1",
-        "@typescript-eslint/visitor-keys": "8.48.1",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -737,20 +1199,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.48.1.tgz",
-      "integrity": "sha512-HQWSicah4s9z2/HifRPQ6b6R7G+SBx64JlFQpgSSHWPKdvCZX57XCbszg/bapbRsOEv42q5tayTYcEFpACcX1w==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+      "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.48.1",
-        "@typescript-eslint/types": "^8.48.1",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.61.1",
+        "@typescript-eslint/types": "^8.61.1",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -760,18 +1222,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.48.1.tgz",
-      "integrity": "sha512-rj4vWQsytQbLxC5Bf4XwZ0/CKd362DkWMUkviT7DCS057SK64D5lH74sSGzhI6PDD2HCEq02xAP9cX68dYyg1w==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
+      "integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.48.1",
-        "@typescript-eslint/visitor-keys": "8.48.1"
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -782,9 +1244,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.48.1.tgz",
-      "integrity": "sha512-k0Jhs4CpEffIBm6wPaCXBAD7jxBtrHjrSgtfCjUvPp9AZ78lXKdTR8fxyZO5y4vWNlOvYXRtngSZNSn+H53Jkw==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+      "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -795,21 +1257,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.48.1.tgz",
-      "integrity": "sha512-1jEop81a3LrJQLTf/1VfPQdhIY4PlGDBc/i67EVWObrtvcziysbLN3oReexHOM6N3jyXgCrkBsZpqwH0hiDOQg==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
+      "integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.48.1",
-        "@typescript-eslint/typescript-estree": "8.48.1",
-        "@typescript-eslint/utils": "8.48.1",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -819,14 +1281,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.48.1.tgz",
-      "integrity": "sha512-+fZ3LZNeiELGmimrujsDCT4CRIbq5oXdHe7chLiW8qzqyPMnn1puNstCrMNVAqwcl2FdIxkuJ4tOs/RFDBVc/Q==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+      "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -838,21 +1300,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.48.1.tgz",
-      "integrity": "sha512-/9wQ4PqaefTK6POVTjJaYS0bynCgzh6ClJHGSBj06XEHjkfylzB+A3qvyaXnErEZSaxhIo4YdyBgq6j4RysxDg==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+      "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.48.1",
-        "@typescript-eslint/tsconfig-utils": "8.48.1",
-        "@typescript-eslint/types": "8.48.1",
-        "@typescript-eslint/visitor-keys": "8.48.1",
-        "debug": "^4.3.4",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
+        "@typescript-eslint/project-service": "8.61.1",
+        "@typescript-eslint/tsconfig-utils": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -862,46 +1324,59 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.48.1.tgz",
-      "integrity": "sha512-fAnhLrDjiVfey5wwFRwrweyRlCmdz5ZxXz2G/4cLn0YDLjTapmN4gcCsTBR1N2rWnZSDeWpYtgLDsJt+FpmcwA==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
+      "integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.48.1",
-        "@typescript-eslint/types": "8.48.1",
-        "@typescript-eslint/typescript-estree": "8.48.1"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -911,19 +1386,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.48.1.tgz",
-      "integrity": "sha512-BmxxndzEWhE4TIEEMBs8lP3MBWN3jFPs/p6gPm/wkv02o41hI6cq9AuSmGAaTTHPtA1FTi2jBre4A9rm5ZmX+Q==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+      "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.48.1",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.61.1",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -931,6 +1406,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1437,6 +1925,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -1855,13 +2385,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1996,10 +2519,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3445,6 +3978,13 @@
         "node": "*"
       }
     },
+    "node_modules/mitata": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/mitata/-/mitata-1.0.34.tgz",
+      "integrity": "sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3706,6 +4246,10 @@
         "node": ">=6"
       }
     },
+    "node_modules/regex-partial-match-benchmarks": {
+      "resolved": "benchmarking",
+      "link": true
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3791,9 +4335,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4052,9 +4596,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4072,6 +4616,25 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4086,9 +4649,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4100,16 +4663,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.48.1.tgz",
-      "integrity": "sha512-FbOKN1fqNoXp1hIl5KYpObVrp0mCn+CLgn479nmu2IsRMrx2vyv74MmsBLVlhg8qVwNFGbXSp8fh1zp8pEoC2A==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
+      "integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.48.1",
-        "@typescript-eslint/parser": "8.48.1",
-        "@typescript-eslint/typescript-estree": "8.48.1",
-        "@typescript-eslint/utils": "8.48.1"
+        "@typescript-eslint/eslint-plugin": "8.61.1",
+        "@typescript-eslint/parser": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4119,9 +4682,16 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unist-util-is": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -79,12 +79,13 @@
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@eslint/markdown": "^7.5.1",
+    "@types/node": "^25.9.3",
     "eslint": "^9.17.0",
     "jiti": "^2.6.1",
     "lint-staged": "^15.2.11",
     "simple-git-hooks": "^2.12.1",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.61.1",
+    "@typescript-eslint/eslint-plugin": "^8.61.1",
     "vitest": "^4.0.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     }
   ],
   "type": "module",
-  "main": "lib/index.js",
+  "main": "lib/partialMatchRegExp.js",
   "exports": {
     ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.js",
-      "default": "./lib/index.js"
+      "types": "./lib/partialMatchRegExp.d.ts",
+      "import": "./lib/partialMatchRegExp.js",
+      "default": "./lib/partialMatchRegExp.js"
     },
     "./extend": {
       "types": "./lib/extend.d.ts",
@@ -53,6 +53,9 @@
     "type": "git",
     "url": "git+https://github.com/TomStrepsil/regex-partial-match.git"
   },
+  "workspaces": [
+    "benchmarking"
+  ],
   "sideEffects": false,
   "scripts": {
     "lint": "eslint .",
@@ -80,8 +83,8 @@
     "jiti": "^2.6.1",
     "lint-staged": "^15.2.11",
     "simple-git-hooks": "^2.12.1",
-    "typescript": "^5.9.3",
-    "typescript-eslint": "^8.18.1",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.61.1",
     "vitest": "^4.0.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "lint-staged": "^15.2.11",
     "simple-git-hooks": "^2.12.1",
     "typescript": "^6.0.3",
-    "@typescript-eslint/eslint-plugin": "^8.61.1",
+    "typescript-eslint": "^8.61.1",
     "vitest": "^4.0.15"
   }
 }

--- a/src/createPartialMatchRegex.test.ts
+++ b/src/createPartialMatchRegex.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import createPartialMatchRegex from "./index.ts";
+import createPartialMatchRegex from "./createPartialMatchRegex.ts";
 
 describe("regexp-partial-match", () => {
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/flags
@@ -23,7 +23,7 @@ describe("regexp-partial-match", () => {
 
     it("should support partial matching of literal character expressions", () => {
       for (let i = 1; i < string.length; i++) {
-        const partialString = string.substring(0, i);
+        const partialString = string.slice(0, i);
         const result = partial.exec(partialString);
         expect(result).toMatchAt({ match: partialString, index: 0 });
       }
@@ -61,6 +61,40 @@ describe("regexp-partial-match", () => {
       expect(partial).toMatchPartially({
         characters: ["a", "́", ..."suffix".split("")]
       });
+    });
+  });
+
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Wildcard
+  describe("wildcard expressions", () => {
+    it("should support partial matching of wildcards", () => {
+      const input = /a.suffix/;
+      const partial = createPartialMatchRegex(input);
+      expect(partial).toMatchPartially({
+        characters: ["a", "x", ..."suffix".split("")]
+      });
+
+      expect(partial.exec("absuffix")).toMatchAt({ match: "absuffix", index: 0 });
+      expect(partial.exec("a\nsuffix")).toNotMatch();
+    });
+
+    it("should support partial matching of utf-16 code units with wildcards, in non-unicode mode", () => {
+      const input = /a..suffix/;
+      const partial = createPartialMatchRegex(input);
+      expect(partial).toMatchPartially({
+        characters: ["a", "😄", ..."suffix".split("")]
+      });
+
+      expect(partial.exec("a😄suffix")).toMatchAt({ match: "a😄suffix", index: 0 });
+    });
+
+    it("should support partial matching of unicode characters with wildcards, in unicode mode", () => {
+      const input = /a.suffix/u;
+      const partial = createPartialMatchRegex(input);
+      expect(partial).toMatchPartially({
+        characters: ["a", "😄", ..."suffix".split("")]
+      });
+
+      expect(partial.exec("a😄suffix")).toMatchAt({ match: "a😄suffix", index: 0 });
     });
   });
 
@@ -425,7 +459,7 @@ describe("regexp-partial-match", () => {
 
       for (const animal of animals) {
         for (let i = 1; i < animal.length; i++) {
-          const partialString = animal.substring(0, i);
+          const partialString = animal.slice(0, i);
           const result = partial.exec(partialString);
           expect(result).toMatchAt({ match: partialString, index: 0 });
         }
@@ -837,7 +871,7 @@ c`)
       const input = /(?-ism:^a.c$)\nsuffix/;
       const partial = createPartialMatchRegex(input);
       expect(partial).toMatchPartially({
-        characters: ["a", ".", "c"]
+        characters: ["a", "b", "c"]
       });
       expect(partial.exec(`abc\n`)).toNotMatch(); // multiline disabled
       expect(partial.exec(`Abc`)).toNotMatch(); // case-insensitive disabled
@@ -1005,7 +1039,7 @@ c`)
       const string = "foobar";
 
       for (let i = 1; i < string.length; i++) {
-        const partialString = string.substring(0, i);
+        const partialString = string.slice(0, i);
         const result = partial.exec(partialString);
         expect(result).toMatchAt({
           match: partialString.slice(0, 3),
@@ -1020,7 +1054,7 @@ c`)
       const string = "foobaz";
 
       for (let i = 1; i < string.length; i++) {
-        const partialString = string.substring(0, i);
+        const partialString = string.slice(0, i);
         const result = partial.exec(partialString);
         expect(result).toMatchAt({
           match: partialString.slice(0, 3),
@@ -1037,7 +1071,7 @@ c`)
       const string = "fooba";
 
       for (let i = 3; i < string.length; i++) {
-        const partialString = string.substring(0, i);
+        const partialString = string.slice(0, i);
         const result = partial.exec(partialString);
         expect(result).toMatchAt({ match: partialString.slice(3), index: 3 });
       }
@@ -1049,7 +1083,7 @@ c`)
       const string = "ba";
 
       for (let i = 1; i < string.length; i++) {
-        const partialString = string.substring(0, i);
+        const partialString = string.slice(0, i);
         const result = partial.exec(partialString);
         expect(result).toMatchAt({ match: partialString, index: 0 });
       }
@@ -1065,7 +1099,7 @@ c`)
       const string = "foobarba";
 
       for (let i = 3; i < string.length; i++) {
-        const partialString = string.substring(0, i);
+        const partialString = string.slice(0, i);
         const result = partial.exec(partialString);
         expect(result).toMatchAt({
           match: partialString.slice(3, 6),
@@ -1081,7 +1115,7 @@ c`)
 
       for (const string of testStrings) {
         for (let i = 1; i < string.length; i++) {
-          const partialString = string.substring(0, i);
+          const partialString = string.slice(0, i);
           const result = partial.exec(partialString);
           expect(result).toMatchAt({
             match: partialString.slice(0, 3),
@@ -1098,7 +1132,7 @@ c`)
       const partial = createPartialMatchRegex(input);
       const string = "abcsuffix";
       for (let i = 2; i < string.length; i++) {
-        const partialString = string.substring(0, i);
+        const partialString = string.slice(0, i);
         const result = partial.exec(partialString);
         expect(result).toMatchObject({
           0: partialString.slice(3),
@@ -1115,7 +1149,7 @@ c`)
 
       for (const string of testStrings) {
         for (let i = 1; i < string.length; i++) {
-          const partialString = string.substring(0, i);
+          const partialString = string.slice(0, i);
           const result = partial.exec(partialString);
           expect(result).toMatchAt({
             match: partialString.slice(0, string.indexOf(":")),
@@ -1134,7 +1168,7 @@ c`)
       const string = "foo";
 
       for (let i = 1; i < string.length; i++) {
-        const partialString = string.substring(0, i);
+        const partialString = string.slice(0, i);
         const result = partial.exec(partialString);
         expect(result).toMatchAt({ match: partialString, index: 0 });
       }
@@ -1148,7 +1182,7 @@ c`)
       const string = "foo";
 
       for (let i = 1; i < string.length; i++) {
-        const partialString = string.substring(0, i);
+        const partialString = string.slice(0, i);
         const result = partial.exec(partialString);
         expect(result).toMatchAt({ match: partialString, index: 0 });
       }
@@ -1163,7 +1197,7 @@ c`)
       const string = "foo\nfoo";
 
       for (let i = 1; i < string.length; i++) {
-        const partialString = string.substring(0, i);
+        const partialString = string.slice(0, i);
         const result = partial.exec(partialString);
         expect(result).toMatchAt({
           match: partialString.slice(0, 3), // always matches up to "foo", stripping newline, before wrapping to next line
@@ -1179,7 +1213,7 @@ c`)
       const string = "f\no\nf\no";
 
       for (let i = 1; i < string.length; i++) {
-        const partialString = string.substring(0, i);
+        const partialString = string.slice(0, i);
         const result = partial.exec(partialString);
         expect(result).toMatchAt({
           match: partialString.slice(0, 3), // always matches up to "foo", stripping newline, before wrapping to next line
@@ -1198,7 +1232,7 @@ c`)
       const string = "foo";
 
       for (let i = 1; i < string.length; i++) {
-        const partialString = string.substring(0, i);
+        const partialString = string.slice(0, i);
         const result = partial.exec(partialString);
         expect(result).toMatchAt({ match: partialString, index: 0 });
       }
@@ -1215,13 +1249,171 @@ c`)
       const string = "xfooy";
 
       for (let i = 1; i < string.length; i++) {
-        const partialString = string.substring(0, i);
+        const partialString = string.slice(0, i);
         const result = partial.exec(partialString);
         expect(result).toMatchAt({ match: partialString.slice(1), index: 1 });
       }
 
       expect(partial.exec("xfooy")).toMatchAt({ match: "foo", index: 1 });
       expect(partial.exec(" foo ")).toNotMatch();
+    });
+  });
+
+  describe("parity with reference implementations", () => {
+
+    // Apache Lucene TestRegExp.java — testRegExpNoStackOverflow
+    // Lucene verifies its automaton builder does not stack-overflow on very deeply nested patterns.
+    describe("deep nesting safety (Lucene-inspired)", () => {
+      it("should not throw on a high-count top-level alternation (wide pattern)", () => {
+        const width = 1000;
+        const pattern = new RegExp(Array(width).fill("(?:a)").join("|") + "|(?:b)");
+        const partial = createPartialMatchRegex(pattern);
+        expect(() => partial.exec("a")).not.toThrow();
+        expect(() => partial.exec("b")).not.toThrow();
+        expect(() => partial.exec("z")).not.toThrow();
+      });
+
+      it("should not throw on deeply nested non-capturing groups", () => {
+        const depth = 100;
+        const pattern = new RegExp("(?:".repeat(depth) + "a" + ")".repeat(depth) + "suffix");
+        const partial = createPartialMatchRegex(pattern);
+        expect(() => partial.exec("a")).not.toThrow();
+        expect(() => partial.exec("asuffix")).not.toThrow();
+      });
+    });
+
+    // Apache Lucene TestRegExp.java — testRepeatWithEmptyString
+    // Lucene tests quantifiers whose subpatterns can match an empty string (e.g. [^y]*{1,2}).
+    describe("quantifiers over empty-matching subpatterns (Lucene-inspired)", () => {
+      it("should support patterns where the quantified atom matches zero characters (a*suffix)", () => {
+        const partial = createPartialMatchRegex(/a*suffix/);
+        // zero repetitions of "a" — falls through directly to "suffix"
+        expect(partial.exec("s")).toMatchAt({ match: "s", index: 0 });
+        expect(partial.exec("suffix")).toMatchAt({ match: "suffix", index: 0 });
+        expect(partial.exec("asuffix")).toMatchAt({ match: "asuffix", index: 0 });
+        expect(partial.exec("aas")).toMatchAt({ match: "aas", index: 0 });
+      });
+
+      it("should support optional (?) quantifier where the atom matches zero characters", () => {
+        const partial = createPartialMatchRegex(/a?suffix/);
+        expect(partial.exec("s")).toMatchAt({ match: "s", index: 0 });
+        expect(partial.exec("as")).toMatchAt({ match: "as", index: 0 });
+        expect(partial.exec("suffix")).toMatchAt({ match: "suffix", index: 0 });
+        expect(partial.exec("asuffix")).toMatchAt({ match: "asuffix", index: 0 });
+      });
+
+      it("should support character class quantifier that can match empty (Lucene [^y]*{1,2} style)", () => {
+        const partial = createPartialMatchRegex(/^[^y]*suffix/);
+        expect(partial).toMatchPartially({ characters: ["a", "b", ..."suffix".split("")] });
+        expect(partial.exec("ysuffix")).toNotMatch(); // y excluded from class; ^ prevents skipping it
+      });
+    });
+
+    // Apache Lucene TestRegExp.java — testUnicodeAsciiInsensitiveFlags
+    // Lucene explicitly tests Unicode case folding (σ/Σ, ῼ, ﬗ) with case-insensitive flags.
+    describe("Unicode case folding (Lucene-inspired)", () => {
+      it("should support case-insensitive partial matching of Greek lowercase sigma (σ) against uppercase (Σ)", () => {
+        const partial = createPartialMatchRegex(/σsuffix/iu);
+        // Σ (U+03A3) is the uppercase of σ (U+03C3) under Unicode case folding
+        expect(partial.exec("Σs")).toMatchAt({ match: "Σs", index: 0 });
+        expect(partial.exec("σs")).toMatchAt({ match: "σs", index: 0 });
+        expect(partial).toMatchPartially({ characters: ["Σ", ..."suffix".split("")] });
+      });
+
+      it("should support case-insensitive partial matching of uppercase sigma (Σ) against lowercase (σ)", () => {
+        const partial = createPartialMatchRegex(/Σsuffix/iu);
+        expect(partial.exec("σs")).toMatchAt({ match: "σs", index: 0 });
+        expect(partial.exec("Σs")).toMatchAt({ match: "Σs", index: 0 });
+      });
+
+      it("should support case-insensitive partial matching of Greek capital letter omega with prosgegrammeni (ῼ)", () => {
+        const partial = createPartialMatchRegex(/ῼsuffix/iu);
+        expect(partial.exec("ῼ")).toMatchAt({ match: "ῼ", index: 0 });
+        expect(partial).toMatchPartially({ characters: ["ῼ", ..."suffix".split("")] });
+      });
+    });
+
+    // JDK RegExTest.java — hitEndTest
+    // Java's Matcher.hitEnd() returns true when the engine consumed all input before failing,
+    // meaning a longer string could potentially produce a match (i.e. the input is a valid prefix).
+    // In this library, a non-empty exec result is the equivalent of hitEnd()=true, and an empty
+    // (or null) result is the equivalent of hitEnd()=false.
+    describe("hitEnd() semantic equivalence (JDK-inspired)", () => {
+      it("returns non-empty prefix match when input is a prefix of the pattern (hitEnd=true equivalent)", () => {
+        // JDK: /^squidattack/.hitEnd("squid") === true — engine ran off end of input
+        const partial = createPartialMatchRegex(/^squidattack/);
+        expect(partial.exec("squid")?.[0]).toBe("squid");
+      });
+
+      it("returns null when input diverges from the pattern before end of input (hitEnd=false equivalent)", () => {
+        // JDK: /^squidattack/.hitEnd("squack") === false — engine diverged at 4th char
+        const partial = createPartialMatchRegex(/^squidattack/);
+        expect(partial.exec("squack")).toBeNull();
+      });
+
+      it("returns non-empty prefix when input is a prefix of a simple literal (JDK: /^abc/ on 'ab')", () => {
+        const partial = createPartialMatchRegex(/^abc/);
+        expect(partial.exec("ab")?.[0]).toBe("ab");
+      });
+
+      it("returns null when input diverges early (JDK: /^abc/ on 'ad')", () => {
+        const partial = createPartialMatchRegex(/^abc/);
+        expect(partial.exec("ad")).toBeNull();
+      });
+
+      it("returns non-empty partial match for a non-anchored pattern occurring mid-string (hitEnd=true via unanchored find)", () => {
+        // JDK: /catattack/ on "attackattackattackcatatta" — hitEnd=true (prefix found at end)
+        const partial = createPartialMatchRegex(/catattack/);
+        const m = partial.exec("attackattackattackcatatta");
+        expect(m).toMatchObject({ 0: "catatta", index: 18 });
+      });
+    });
+
+    // JDK RegExTest.java — caretAtEndTest
+    // Java tests that ^ with MULTILINE matches at the start of a new line after \r (bare CR).
+    describe("CRLF boundary in multiline mode (JDK caretAtEndTest-inspired)", () => {
+      it("should recognise ^ at position 0 and after bare CR in multiline mode", () => {
+        // Use "\rfoo" so the second line is non-empty and the engine can find a match there.
+        // For zero-length matches, lastIndex must be advanced manually — standard JS pattern.
+        const partial = createPartialMatchRegex(/^x?/gm);
+        const m1 = partial.exec("\rfoo");
+        expect(m1).toMatchObject({ index: 0 });
+        if (m1?.[0] === "") partial.lastIndex++; // advance past zero-length match
+        const m2 = partial.exec("\rfoo");
+        expect(m2).toMatchObject({ index: 1 }); // ^ matches at start of new line after \r
+      });
+
+      it("should match $ before bare CR in multiline mode", () => {
+        const partial = createPartialMatchRegex(/^foo$/m);
+        // \r is a line terminator in multiline mode, so "foo" is a complete line
+        expect(partial.exec("foo\r")).toMatchAt({ match: "foo", index: 0 });
+      });
+    });
+
+    // JDK RegExTest.java — wordSearchTest
+    // Java's Matcher.find(pos) advances through successive matches by position.
+    // The equivalent in JS is advancing lastIndex on a global-flag regex.
+    describe("progressive find() via lastIndex (JDK wordSearchTest-inspired)", () => {
+      it("should find successive word-prefixed partial matches by advancing lastIndex", () => {
+        // JDK wordSearchTest: /\b/ on "word1 word2 word3" with progressive find(pos) calls
+        const partial = createPartialMatchRegex(/\bwor/g);
+        const input = "word1 word2 word3";
+        const positions: number[] = [];
+        let m;
+        while ((m = partial.exec(input)) !== null && m[0] !== "") {
+          positions.push(m.index);
+        }
+        expect(positions).toEqual([0, 6, 12]);
+      });
+
+      it("should support find(position) equivalent by setting lastIndex before exec", () => {
+        const partial = createPartialMatchRegex(/\bwor/g);
+        const input = "word1 word2 word3";
+        // Start from position 6 (equivalent to JDK's find(6))
+        partial.lastIndex = 6;
+        const m = partial.exec(input);
+        expect(m).toMatchObject({ 0: "wor", index: 6 });
+      });
     });
   });
 

--- a/src/createPartialMatchRegex.test.ts
+++ b/src/createPartialMatchRegex.test.ts
@@ -1260,7 +1260,6 @@ c`)
   });
 
   describe("parity with reference implementations", () => {
-
     // Apache Lucene TestRegExp.java — testRegExpNoStackOverflow
     // Lucene verifies its automaton builder does not stack-overflow on very deeply nested patterns.
     describe("deep nesting safety (Lucene-inspired)", () => {

--- a/src/createPartialMatchRegex.test.ts
+++ b/src/createPartialMatchRegex.test.ts
@@ -81,7 +81,7 @@ describe("regexp-partial-match", () => {
       const input = /a..suffix/;
       const partial = createPartialMatchRegex(input);
       expect(partial).toMatchPartially({
-        characters: ["a", "😄", ..."suffix".split("")]
+        characters: ["a", ..."😄".split(""), ..."suffix".split("")]
       });
 
       expect(partial.exec("a😄suffix")).toMatchAt({ match: "a😄suffix", index: 0 });

--- a/src/createPartialMatchRegex.ts
+++ b/src/createPartialMatchRegex.ts
@@ -7,19 +7,19 @@ const createPartialMatchRegex = (regex: RegExp): RegExp => {
 
   let i = 0;
 
-  function extractSubstring(length: number): string {
-    return source.substring(i, (i += length));
+  function extractslice(length: number): string {
+    return source.slice(i, (i += length));
   }
 
   function process() {
     let result = "";
 
     function appendOptional(length: number) {
-      result += "(?:" + extractSubstring(length) + "|$)";
+      result += "(?:" + extractslice(length) + "|$)";
     }
 
     function appendRaw(length: number) {
-      result += extractSubstring(length);
+      result += extractslice(length);
     }
 
     while (i < source.length) {
@@ -128,7 +128,7 @@ const createPartialMatchRegex = (regex: RegExp): RegExp => {
               case "m":
                 const temp = i + 2,
                   temp2 = source.indexOf(":", temp);
-                result += "(?" + source.substring(temp, temp2) + ":";
+                result += "(?" + source.slice(temp, temp2) + ":";
                 i = temp2 + 1;
                 result += process() + ")";
                 break;
@@ -136,7 +136,7 @@ const createPartialMatchRegex = (regex: RegExp): RegExp => {
                 const temp = i;
                 i += 3;
                 process();
-                result += source.substring(temp, i);
+                result += source.slice(temp, i);
                 break;
               }
               case "<":
@@ -146,7 +146,7 @@ const createPartialMatchRegex = (regex: RegExp): RegExp => {
                     const temp = i;
                     i += 4;
                     process();
-                    result += source.substring(temp, i);
+                    result += source.slice(temp, i);
                     break;
                   }
                   default:

--- a/src/createPartialMatchRegex.ts
+++ b/src/createPartialMatchRegex.ts
@@ -7,7 +7,7 @@ const createPartialMatchRegex = (regex: RegExp): RegExp => {
 
   let i = 0;
 
-  function extractslice(length: number): string {
+  function extractSlice(length: number): string {
     return source.slice(i, (i += length));
   }
 
@@ -15,11 +15,11 @@ const createPartialMatchRegex = (regex: RegExp): RegExp => {
     let result = "";
 
     function appendOptional(length: number) {
-      result += "(?:" + extractslice(length) + "|$)";
+      result += "(?:" + extractSlice(length) + "|$)";
     }
 
     function appendRaw(length: number) {
-      result += extractslice(length);
+      result += extractSlice(length);
     }
 
     while (i < source.length) {

--- a/src/extend.test.ts
+++ b/src/extend.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { PartialMatchRegExp } from "./partialMatchRegExp.ts";
 
 describe("RegExp.prototype.toPartialMatchRegex", () => {
   beforeAll(async () => {
@@ -13,14 +14,15 @@ describe("RegExp.prototype.toPartialMatchRegex", () => {
     expect(typeof /foo/.toPartialMatchRegex).toBe("function");
   });
 
-  it("should return a RegExp instance", () => {
+  it("should return a PartialMatchRegExp instance", () => {
     const partial = /foo/.toPartialMatchRegex();
+    expect(partial).toBeInstanceOf(PartialMatchRegExp);
     expect(partial).toBeInstanceOf(RegExp);
   });
 
   it("should produce a partial matching regex", () => {
     const partial = /foo/.toPartialMatchRegex();
-    expect(partial.exec("fo")?.[0]).not.toEqual("");
-    expect(partial.exec("bar")?.[0]).toEqual("");
+    expect(partial.exec("fo")?.[0]).toBe("fo");
+    expect(partial.exec("bar")).toBeNull();
   });
 });

--- a/src/extend.ts
+++ b/src/extend.ts
@@ -24,8 +24,7 @@ declare global {
      * ```
      *
      * @remarks
-     * - The transformed regex will always match an empty string at the end of input
-     * - Use with a start anchor (`^`) to prevent false positives from empty string matches
+     * - Backreferences cannot be partially matched as they are atomic
      * - The `y` (sticky) flag may not behave as expected in partial matching scenarios
      *
      * @see {@link https://github.com/TomStrepsil/regex-partial-match#readme | Documentation}

--- a/src/extend.ts
+++ b/src/extend.ts
@@ -1,40 +1,39 @@
-import createPartialMatchRegex from "./index.ts";
+import PartialMatchRegExp from "./partialMatchRegExp.ts";
 
 declare global {
   interface RegExp {
     /**
      * Transforms this regular expression to support partial matching.
-     * 
+     *
      * This method wraps each atomic element of the regex pattern in a non-capturing group
      * with an alternation to end-of-input (`$`), allowing the pattern to match prefixes
      * of the original pattern. This enables validation of incomplete input strings.
-     * 
-     * @returns A new RegExp that matches partial strings of the original pattern
-     * 
+     *
+     * @returns A new PartialMatchRegExp that matches partial strings of the original pattern
+     *
      * @example
      * ```typescript
      * import 'regex-partial-match/extend';
-     * 
+     *
      * const partial = /hello world/.toPartialMatchRegex();
-     * 
+     *
      * partial.test('h');           // true - could match
      * partial.test('hello');       // true - could match
      * partial.test('hello world'); // true - full match
      * partial.test('goodbye');     // false - cannot match
      * ```
-     * 
+     *
      * @remarks
      * - The transformed regex will always match an empty string at the end of input
-     * - Backreferences cannot be partially matched as they are atomic
      * - Use with a start anchor (`^`) to prevent false positives from empty string matches
      * - The `y` (sticky) flag may not behave as expected in partial matching scenarios
-     * 
+     *
      * @see {@link https://github.com/TomStrepsil/regex-partial-match#readme | Documentation}
      */
-    toPartialMatchRegex(): RegExp;
+    toPartialMatchRegex(): PartialMatchRegExp;
   }
 }
 
 RegExp.prototype.toPartialMatchRegex = function () {
-  return createPartialMatchRegex(this);
+  return new PartialMatchRegExp(this);
 };

--- a/src/partialMatchRegExp.test.ts
+++ b/src/partialMatchRegExp.test.ts
@@ -71,135 +71,215 @@ describe("PartialMatchRegExp", () => {
 
 [
   // ── Literals ──────────────────────────────────────────────────────────────
-  { pattern: /^abc/, inputs: ["a", "ab", "abc", "xyz", "123", "!"] },
+  {
+    pattern: /^abc/,
+    expected: ["a", "ab", "abc"],
+    notExpected: ["xyz", "123", "!"]
+  },
   {
     pattern: /^hello world/,
-    inputs: ["h", "he", "hel", "hello", "hello ", "hello world", "goodbye"]
+    expected: ["h", "he", "hel", "hello", "hello ", "hello world"],
+    notExpected: ["goodbye"]
   },
   // ── Character escapes ─────────────────────────────────────────────────────
-  { pattern: /^\x61\x62\x63/, inputs: ["a", "ab", "abc", "xyz"] },
-  { pattern: /^\u0061\u0062/, inputs: ["a", "ab", "xyz"] },
-  { pattern: /^\u{1F600}/u, inputs: ["😀", "xyz"] },
+  {
+    pattern: /^\x61\x62\x63/,
+    expected: ["a", "ab", "abc"],
+    notExpected: ["xyz"]
+  },
+  {
+    pattern: /^\u0061\u0062/,
+    expected: ["a", "ab"],
+    notExpected: ["xyz"]
+  },
+  {
+    pattern: /^\u{1F600}/u,
+    expected: ["😀"],
+    notExpected: ["xyz"]
+  },
   {
     pattern: /^\p{Lowercase_Letter}+suffix/u,
-    inputs: ["a", "ab", "asuffix", "Asuffix", "1suffix"]
+    expected: ["a", "ab", "asuffix"],
+    notExpected: ["Asuffix", "1suffix"]
   },
-  { pattern: /^\cj\cMsuffix/, inputs: ["\n", "\n\r", "\n\rsuffix", "x"] },
+  {
+    pattern: /^\cj\cMsuffix/,
+    expected: ["\n", "\n\r", "\n\rsuffix"],
+    notExpected: ["x"]
+  },
   // ── Character classes ─────────────────────────────────────────────────────
-  { pattern: /^[a-z]+/, inputs: ["a", "ab", "A", "1"] },
+  {
+    pattern: /^[a-z]+/,
+    expected: ["a", "ab"],
+    notExpected: ["A", "1"]
+  },
   {
     pattern: /^[^abc]+suffix/,
-    inputs: ["x", "xy", "xysuffix", "asuffix", "bsuffix"]
+    expected: ["x", "xy", "xysuffix"],
+    notExpected: ["asuffix", "bsuffix"]
   },
-  { pattern: /^[ab\\]suffix/, inputs: ["a", "asuffix", "\\suffix", "csuffix"] },
+  {
+    pattern: /^[ab\\]suffix/,
+    expected: ["a", "asuffix", "\\suffix"],
+    notExpected: ["csuffix"]
+  },
   {
     pattern: /^[a-c]suffix/i,
-    inputs: ["A", "Asuffix", "Bsuffix", "Csuffix", "dsuffix"]
+    expected: ["A", "Asuffix", "Bsuffix", "Csuffix"],
+    notExpected: ["dsuffix"]
   },
   {
     pattern: /^[a-z]+\s\w+/,
-    inputs: ["a", "ab", " ", "ab ", "ab c", "ab cd", "!", "123"]
+    expected: ["a", "ab", "ab ", "ab c", "ab cd"],
+    notExpected: [" ", "!", "123"]
   },
   // ── Disjunction ───────────────────────────────────────────────────────────
   {
     pattern: /^foo|^bar/,
-    inputs: ["f", "fo", "foo", "b", "ba", "bar", "xyz", "123", "!"]
+    expected: ["f", "fo", "foo", "b", "ba", "bar"],
+    notExpected: ["xyz", "123", "!"]
   },
-  { pattern: /^cat|^dog/, inputs: ["c", "ca", "cat", "d", "do", "dog", "xyz"] },
+  {
+    pattern: /^cat|^dog/,
+    expected: ["c", "ca", "cat", "d", "do", "dog"],
+    notExpected: ["xyz"]
+  },
   // ── Quantifiers ───────────────────────────────────────────────────────────
   {
     pattern: /^\d{3}-\d{4}/,
-    inputs: [
-      "1",
-      "12",
-      "123",
-      "123-",
-      "123-4",
-      "123-45",
-      "123-456",
-      "123-4567",
-      "xyz",
-      "!"
-    ]
+    expected: ["1", "12", "123", "123-", "123-4", "123-45", "123-456", "123-4567"],
+    notExpected: ["xyz", "!"]
   },
-  { pattern: /^ab*c/, inputs: ["a", "ab", "abc", "abbc", "ac", "b", "axc"] },
-  { pattern: /^ab+c/, inputs: ["ab", "abc", "abbc", "a", "ac"] },
-  { pattern: /^ab?c/, inputs: ["a", "ab", "abc", "ac", "axc"] },
+  {
+    pattern: /^ab*c/,
+    expected: ["a", "ab", "abc", "abbc", "ac"],
+    notExpected: ["b", "axc"]
+  },
+  {
+    pattern: /^ab+c/,
+    expected: ["ab", "abc", "abbc", "a"],
+    notExpected: ["ac"]
+  },
+  {
+    pattern: /^ab?c/,
+    expected: ["a", "ab", "abc", "ac"],
+    notExpected: ["axc"]
+  },
   {
     pattern: /^ab{2,4}c/,
-    inputs: ["ab", "abb", "abbb", "abbbb", "abbbbc", "abc", "abbbbbbc"]
+    expected: ["ab", "abb", "abbb", "abbbb", "abbbbc"],
+    notExpected: ["abc", "abbbbbbc"]
   },
-  { pattern: /^ab*?c/, inputs: ["a", "ab", "abc", "abbc", "ac", "axc"] },
+  {
+    pattern: /^ab*?c/,
+    expected: ["a", "ab", "abc", "abbc", "ac"],
+    notExpected: ["axc"]
+  },
   // ── Unicode sets (v flag) ─────────────────────────────────────────────────
   {
     pattern: /^[\p{Alphabetic}]+suffix/v,
-    inputs: ["a", "aあ", "aあsuffix", "1suffix", "!suffix"]
+    expected: ["a", "aあ", "aあsuffix"],
+    notExpected: ["1suffix", "!suffix"]
   },
   // ── Modifiers ─────────────────────────────────────────────────────────────
   {
     pattern: /^(?i:abc)suffix/,
-    inputs: ["A", "AB", "ABC", "ABCsuffix", "abcsuffix", "xyz"]
+    expected: ["A", "AB", "ABC", "ABCsuffix", "abcsuffix"],
+    notExpected: ["xyz"]
   },
   {
     pattern: /^(?-i:abc)suffix/i,
-    inputs: ["a", "ab", "abcsuffix", "ABCsuffix", "xyz"]
+    expected: ["a", "ab", "abcsuffix"],
+    notExpected: ["ABCsuffix", "xyz"]
   },
   // ── Groups ────────────────────────────────────────────────────────────────
   {
     pattern: /^(foo)(bar)/,
-    inputs: ["f", "fo", "foo", "foob", "fooba", "foobar", "xyz"]
+    expected: ["f", "fo", "foo", "foob", "fooba", "foobar"],
+    notExpected: ["xyz"]
   },
   {
     pattern: /^(?:foo)(bar)/,
-    inputs: ["f", "fo", "foo", "foob", "foobar", "xyz"]
+    expected: ["f", "fo", "foo", "foob", "foobar"],
+    notExpected: ["xyz"]
   },
   {
     pattern: /^(?<tag>foo)bar/,
-    inputs: ["f", "fo", "foo", "foob", "foobar", "xyz"]
+    expected: ["f", "fo", "foo", "foob", "foobar"],
+    notExpected: ["xyz"]
   },
   {
     pattern: /^(ab(cd)e)f/,
-    inputs: ["a", "ab", "abc", "abcd", "abcde", "abcdef", "xyz"]
+    expected: ["a", "ab", "abc", "abcd", "abcde", "abcdef"],
+    notExpected: ["xyz"]
   },
   // ── Lookahead assertions ──────────────────────────────────────────────────
   {
     pattern: /^foo(?=bar)/,
-    inputs: ["f", "fo", "foo", "foob", "foobar", "fox"]
+    expected: ["f", "fo", "foo", "foob", "foobar"],
+    notExpected: ["fox"]
   },
   {
     pattern: /^foo(?!baz)/,
-    inputs: ["f", "fo", "foo", "foob", "foobaz", "foobar"]
+    expected: ["f", "fo", "foo", "foob", "foobar"],
+    notExpected: ["foobaz"]
   },
   // ── Lookbehind assertions ─────────────────────────────────────────────────
   {
     pattern: /(?<=foo)bar/,
-    inputs: ["b", "ba", "bar", "foob", "fooba", "foobar", "xbar"]
+    expected: ["foob", "fooba", "foobar"],
+    notExpected: ["b", "ba", "bar", "xbar"]
   },
   {
     pattern: /(?<!foo)bar/,
-    inputs: ["b", "ba", "bar", "foob", "foobar", "xbar"]
+    expected: ["b", "ba", "bar", "xbar"],
+    notExpected: ["foob", "foobar"]
   },
   // ── Boundary assertions ───────────────────────────────────────────────────
-  { pattern: /^foo$/, inputs: ["f", "fo", "foo", "foo ", "xfoo"] },
-  { pattern: /^\bfoo\b/, inputs: ["f", "fo", "foo", "foob", "xfoo"] },
-  { pattern: /^\Bfoo\B/, inputs: ["f", "fo", "foo", "xfooy", "xfoo"] },
+  {
+    pattern: /^foo$/,
+    expected: ["f", "fo", "foo"],
+    notExpected: ["foo ", "xfoo"]
+  },
+  {
+    pattern: /^\bfoo\b/,
+    expected: ["f", "fo", "foo"],
+    notExpected: ["foob", "xfoo"]
+  },
+  {
+    pattern: /^\Bfoo\B/,
+    expected: [],
+    notExpected: ["f", "fo", "foo", "xfooy", "xfoo"]
+  },
   // ── Multiline ─────────────────────────────────────────────────────────────
-  { pattern: /^foo$/m, inputs: ["f", "fo", "foo", "foo ", "foo\nbar"] }
-].forEach(({ pattern, inputs }) => {
-  it(`fast-path parity with createPartialMatchRegex: /${pattern.source}/${pattern.flags}`, () => {
-    const fast = new PartialMatchRegExp(pattern);
+  {
+    pattern: /^foo$/m,
+    expected: ["f", "fo", "foo", "foo\nbar"],
+    notExpected: ["foo "]
+  },
+  // ── End-of-input anchors ──────────────────────────────────────────────────
+  {
+    pattern: /$/,
+    expected: ["", "a", "abc"],
+    notExpected: []
+  },
+  {
+    pattern: /^x*$/,
+    expected: ["", "x", "xx"],
+    notExpected: ["y"]
+  }
+].forEach(({ pattern, expected, notExpected }) => {
+  it(`parity with createPartialMatchRegex: /${pattern.source}/${pattern.flags}`, () => {
+    const re = new PartialMatchRegExp(pattern);
     const ref = createPartialMatchRegex(pattern);
-    const originalMatchesEmpty = new RegExp(pattern.source, pattern.flags).test(
-      ""
-    );
-    for (const s of inputs) {
-      // PartialMatchRegExp suppresses sentinel matches (empty match at end-of-input)
-      // that createPartialMatchRegex exposes as ["", index: s.length, ...].
-      const m = ref.exec(s);
-      const expected =
-        m !== null &&
-        (m.index < s.length || (s.length === 0 && originalMatchesEmpty));
-      expect(fast.test(s)).toBe(expected);
+    for (const s of expected) {
+      expect(re.test(s), s).toBe(true);
+      expect(ref.exec(s)).not.toBeNull();
+    }
+    for (const s of notExpected) {
+      expect(re.test(s), s).toBe(false);
+      const refMatch = ref.exec(s);
+      expect(refMatch === null || refMatch.index === s.length).toBe(true);
     }
   });
 });
@@ -267,5 +347,31 @@ describe("sentinel suppression — exec/test return null/false for non-matching 
   it("sticky regex: test('') mirrors whether the original pattern matches empty", () => {
     expect(new PartialMatchRegExp(/^a*/y).test("")).toBe(true);
     expect(new PartialMatchRegExp(/^foo/y).test("")).toBe(false);
+  });
+});
+
+describe("end-of-input matches — not suppressed when original matches there", () => {
+  it("/$/ already matches end of a non-empty string, so test returns true", () => {
+    expect(new PartialMatchRegExp(/$/).test("abc")).toBe(true);
+    expect(new PartialMatchRegExp(/$/).test("a")).toBe(true);
+  });
+
+  it("/$/ matches the empty string", () => {
+    expect(new PartialMatchRegExp(/$/).test("")).toBe(true);
+  });
+
+  it("exec() returns the match object (not null) for /$/ on a non-empty string", () => {
+    const m = new PartialMatchRegExp(/$/).exec("abc");
+    expect(m).toMatchObject({ 0: "", index: 3 });
+  });
+
+  it("/^x*$/ returns true for complete matches like 'xx'", () => {
+    expect(new PartialMatchRegExp(/^x*$/).test("xx")).toBe(true);
+    expect(new PartialMatchRegExp(/^x*$/).test("")).toBe(true);
+  });
+
+  it("sentinels from patterns that cannot yet match at end-of-input are still suppressed", () => {
+    expect(new PartialMatchRegExp(/^abc/).test("xy")).toBe(false);
+    expect(new PartialMatchRegExp(/a$/).test("bc")).toBe(false);
   });
 });

--- a/src/partialMatchRegExp.test.ts
+++ b/src/partialMatchRegExp.test.ts
@@ -67,6 +67,13 @@ describe("PartialMatchRegExp", () => {
     expect(re.exec("abxyab")).toMatchObject({ 0: "ab", index: 4 });
     expect(re.lastIndex).toBe(6);
   });
+
+  it("g+y flags: constructor does not throw when both g and y are combined", () => {
+    const re = new PartialMatchRegExp(/ab/gy);
+    expect(re.global).toBe(true);
+    expect(re.sticky).toBe(true);
+    expect(re.exec("ab")).toMatchObject({ 0: "ab", index: 0 });
+  });
 });
 
 [
@@ -147,7 +154,16 @@ describe("PartialMatchRegExp", () => {
   // ── Quantifiers ───────────────────────────────────────────────────────────
   {
     pattern: /^\d{3}-\d{4}/,
-    expected: ["1", "12", "123", "123-", "123-4", "123-45", "123-456", "123-4567"],
+    expected: [
+      "1",
+      "12",
+      "123",
+      "123-",
+      "123-4",
+      "123-45",
+      "123-456",
+      "123-4567"
+    ],
     notExpected: ["xyz", "!"]
   },
   {
@@ -284,94 +300,117 @@ describe("PartialMatchRegExp", () => {
   });
 });
 
-describe("sentinel suppression — exec/test return null/false for non-matching inputs", () => {
-  it("test() returns false for a string that cannot match", () => {
-    const re = new PartialMatchRegExp(/^foo/);
-    expect(re.test("bar")).toBe(false);
-    expect(re.test("xyz")).toBe(false);
-    expect(re.test("foobar".slice(3))).toBe(false); // "bar"
+describe("sentinel suppression", () => {
+  describe("exec/test return null/false for non-matching inputs", () => {
+    it("test() returns false for a string that cannot match", () => {
+      const re = new PartialMatchRegExp(/^foo/);
+      expect(re.test("bar")).toBe(false);
+      expect(re.test("xyz")).toBe(false);
+      expect(re.test("foobar".slice(3))).toBe(false); // "bar"
+    });
+
+    it("exec() returns null for a string that cannot match", () => {
+      const re = new PartialMatchRegExp(/^foo/);
+      expect(re.exec("bar")).toBeNull();
+      expect(re.exec("xyz")).toBeNull();
+    });
+
+    it("valid prefixes are not suppressed", () => {
+      const re = new PartialMatchRegExp(/^foobar/);
+      expect(re.test("f")).toBe(true);
+      expect(re.test("fo")).toBe(true);
+      expect(re.test("foo")).toBe(true);
+      expect(re.test("foob")).toBe(true);
+      expect(re.test("fooba")).toBe(true);
+      expect(re.test("foobar")).toBe(true);
+    });
+
+    it("empty string returns false when the original pattern does not match empty", () => {
+      expect(new PartialMatchRegExp(/^foo/).test("")).toBe(false);
+      expect(new PartialMatchRegExp(/^[a-z]+/).test("")).toBe(false);
+    });
+
+    it("empty string returns true when the original pattern matches empty", () => {
+      expect(new PartialMatchRegExp(/^a*/).test("")).toBe(true);
+      expect(new PartialMatchRegExp(/^x?$/).test("")).toBe(true);
+      expect(new PartialMatchRegExp(/^$/).test("")).toBe(true);
+    });
+
+    it("string.match() returns null for non-matching input", () => {
+      const re = new PartialMatchRegExp(/^foo/);
+      expect("bar".match(re)).toBeNull();
+      expect("fo".match(re)).not.toBeNull();
+    });
+
+    it("global regex with non-zero lastIndex resets lastIndex to 0 after sentinel suppression", () => {
+      const re = new PartialMatchRegExp(/foo/g);
+      re.lastIndex = 1;
+      expect(re.exec("XXX")).toBeNull();
+      expect(re.lastIndex).toBe(0);
+    });
+
+    it("sticky regex resets lastIndex to 0 after sentinel suppression", () => {
+      const re = new PartialMatchRegExp(/foo/y);
+      re.lastIndex = 3;
+      expect(re.exec("XXX")).toBeNull();
+      expect(re.lastIndex).toBe(0);
+    });
+
+    it("global regex: test('') mirrors whether the original pattern matches empty", () => {
+      expect(new PartialMatchRegExp(/^a*/g).test("")).toBe(true);
+      expect(new PartialMatchRegExp(/^foo/g).test("")).toBe(false);
+    });
+
+    it("sticky regex: test('') mirrors whether the original pattern matches empty", () => {
+      expect(new PartialMatchRegExp(/^a*/y).test("")).toBe(true);
+      expect(new PartialMatchRegExp(/^foo/y).test("")).toBe(false);
+    });
   });
 
-  it("exec() returns null for a string that cannot match", () => {
-    const re = new PartialMatchRegExp(/^foo/);
-    expect(re.exec("bar")).toBeNull();
-    expect(re.exec("xyz")).toBeNull();
+  describe("with multiline flag — mid-string line-boundary sentinels", () => {
+    it("test() returns false when the only match is an empty sentinel at a mid-string line boundary", () => {
+      expect(new PartialMatchRegExp(/foo/m).test("abc\ndef")).toBe(false);
+    });
+
+    it("exec() returns null in the same case", () => {
+      expect(new PartialMatchRegExp(/foo/m).exec("abc\ndef")).toBeNull();
+    });
+
+    it("test() returns true when the original pattern genuinely matches at a mid-string line boundary", () => {
+      expect(new PartialMatchRegExp(/$/m).test("abc\n")).toBe(true);
+    });
+
+    it("exec() returns the match object when the original pattern genuinely matches at a mid-string line boundary", () => {
+      expect(new PartialMatchRegExp(/$/m).exec("abc\n")).toMatchObject({
+        0: "",
+        index: 3
+      });
+    });
   });
 
-  it("valid prefixes are not suppressed", () => {
-    const re = new PartialMatchRegExp(/^foobar/);
-    expect(re.test("f")).toBe(true);
-    expect(re.test("fo")).toBe(true);
-    expect(re.test("foo")).toBe(true);
-    expect(re.test("foob")).toBe(true);
-    expect(re.test("fooba")).toBe(true);
-    expect(re.test("foobar")).toBe(true);
-  });
+  describe("end-of-input matches — not suppressed when original matches there", () => {
+    it("/$/ already matches end of a non-empty string, so test returns true", () => {
+      expect(new PartialMatchRegExp(/$/).test("abc")).toBe(true);
+      expect(new PartialMatchRegExp(/$/).test("a")).toBe(true);
+    });
 
-  it("empty string returns false when the original pattern does not match empty", () => {
-    expect(new PartialMatchRegExp(/^foo/).test("")).toBe(false);
-    expect(new PartialMatchRegExp(/^[a-z]+/).test("")).toBe(false);
-  });
+    it("/$/ matches the empty string", () => {
+      expect(new PartialMatchRegExp(/$/).test("")).toBe(true);
+    });
 
-  it("empty string returns true when the original pattern matches empty", () => {
-    expect(new PartialMatchRegExp(/^a*/).test("")).toBe(true);
-    expect(new PartialMatchRegExp(/^x?$/).test("")).toBe(true);
-    expect(new PartialMatchRegExp(/^$/).test("")).toBe(true);
-  });
+    it("exec() returns the match object (not null) for /$/ on a non-empty string", () => {
+      const m = new PartialMatchRegExp(/$/).exec("abc");
+      expect(m).toMatchObject({ 0: "", index: 3 });
+    });
 
-  it("string.match() returns null for non-matching input", () => {
-    const re = new PartialMatchRegExp(/^foo/);
-    expect("bar".match(re)).toBeNull();
-    expect("fo".match(re)).not.toBeNull();
-  });
+    it("/^x*$/ returns true for complete matches like 'xx'", () => {
+      expect(new PartialMatchRegExp(/^x*$/).test("xx")).toBe(true);
+      expect(new PartialMatchRegExp(/^x*$/).test("")).toBe(true);
+    });
 
-  it("global regex with non-zero lastIndex resets lastIndex to 0 after sentinel suppression", () => {
-    const re = new PartialMatchRegExp(/foo/g);
-    re.lastIndex = 1;
-    expect(re.exec("XXX")).toBeNull();
-    expect(re.lastIndex).toBe(0);
-  });
-
-  it("sticky regex resets lastIndex to 0 after sentinel suppression", () => {
-    const re = new PartialMatchRegExp(/foo/y);
-    re.lastIndex = 3;
-    expect(re.exec("XXX")).toBeNull();
-    expect(re.lastIndex).toBe(0);
-  });
-
-  it("global regex: test('') mirrors whether the original pattern matches empty", () => {
-    expect(new PartialMatchRegExp(/^a*/g).test("")).toBe(true);
-    expect(new PartialMatchRegExp(/^foo/g).test("")).toBe(false);
-  });
-
-  it("sticky regex: test('') mirrors whether the original pattern matches empty", () => {
-    expect(new PartialMatchRegExp(/^a*/y).test("")).toBe(true);
-    expect(new PartialMatchRegExp(/^foo/y).test("")).toBe(false);
-  });
-});
-
-describe("end-of-input matches — not suppressed when original matches there", () => {
-  it("/$/ already matches end of a non-empty string, so test returns true", () => {
-    expect(new PartialMatchRegExp(/$/).test("abc")).toBe(true);
-    expect(new PartialMatchRegExp(/$/).test("a")).toBe(true);
-  });
-
-  it("/$/ matches the empty string", () => {
-    expect(new PartialMatchRegExp(/$/).test("")).toBe(true);
-  });
-
-  it("exec() returns the match object (not null) for /$/ on a non-empty string", () => {
-    const m = new PartialMatchRegExp(/$/).exec("abc");
-    expect(m).toMatchObject({ 0: "", index: 3 });
-  });
-
-  it("/^x*$/ returns true for complete matches like 'xx'", () => {
-    expect(new PartialMatchRegExp(/^x*$/).test("xx")).toBe(true);
-    expect(new PartialMatchRegExp(/^x*$/).test("")).toBe(true);
-  });
-
-  it("sentinels from patterns that cannot yet match at end-of-input are still suppressed", () => {
-    expect(new PartialMatchRegExp(/^abc/).test("xy")).toBe(false);
-    expect(new PartialMatchRegExp(/a$/).test("bc")).toBe(false);
+    it("sentinels from patterns that cannot yet match at end-of-input are still suppressed", () => {
+      expect(new PartialMatchRegExp(/^abc/).test("xy")).toBe(false);
+      expect(new PartialMatchRegExp(/a$/).test("bc")).toBe(false);
+    });
   });
 });

--- a/src/partialMatchRegExp.test.ts
+++ b/src/partialMatchRegExp.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect } from "vitest";
+import { PartialMatchRegExp } from "./partialMatchRegExp.ts";
+import createPartialMatchRegex from "./createPartialMatchRegex.ts";
+
+describe("PartialMatchRegExp", () => {
+  it("is an instance of RegExp", () => {
+    expect(new PartialMatchRegExp(/abc/)).toBeInstanceOf(RegExp);
+  });
+
+  it("passes flags through from a RegExp argument", () => {
+    expect(new PartialMatchRegExp(/abc/d).hasIndices).toBe(true);
+    expect(new PartialMatchRegExp(/abc/g).global).toBe(true);
+    expect(new PartialMatchRegExp(/abc/i).ignoreCase).toBe(true);
+    expect(new PartialMatchRegExp(/abc/m).multiline).toBe(true);
+    expect(new PartialMatchRegExp(/abc/s).dotAll).toBe(true);
+    expect(new PartialMatchRegExp(/abc/u).unicode).toBe(true);
+    expect(new PartialMatchRegExp(/abc/v).unicodeSets).toBe(true);
+    expect(new PartialMatchRegExp(/abc/y).sticky).toBe(true);
+    expect(new PartialMatchRegExp(/abc/gi).global).toBe(true);
+    expect(new PartialMatchRegExp(/abc/gi).ignoreCase).toBe(true);
+    expect(new PartialMatchRegExp(/abc/i, "m").ignoreCase).toBe(false);
+    expect(new PartialMatchRegExp(/abc/i, "m").multiline).toBe(true);
+  });
+
+  it("applies the flags argument when pattern is a string", () => {
+    expect(new PartialMatchRegExp("abc").ignoreCase).toBe(false);
+    expect(new PartialMatchRegExp("abc", "d").hasIndices).toBe(true);
+    expect(new PartialMatchRegExp("abc", "i").ignoreCase).toBe(true);
+    expect(new PartialMatchRegExp("abc", "m").multiline).toBe(true);
+    expect(new PartialMatchRegExp("abc", "s").dotAll).toBe(true);
+    expect(new PartialMatchRegExp("abc", "u").unicode).toBe(true);
+    expect(new PartialMatchRegExp("abc", "v").unicodeSets).toBe(true);
+    expect(new PartialMatchRegExp("abc", "y").sticky).toBe(true);
+    expect(new PartialMatchRegExp("abc", "g").global).toBe(true);
+    expect(new PartialMatchRegExp("abc", "gi").global).toBe(true);
+    expect(new PartialMatchRegExp("abc", "gi").ignoreCase).toBe(true);
+  });
+
+  it("global flag: lastIndex advances past the match so iteration can continue forward", () => {
+    const re = new PartialMatchRegExp(/ab/g);
+    expect(re.exec("abxyab")?.[0]).toBe("ab");
+    expect(re.lastIndex).toBe(2);
+    expect(re.exec("abxyab")?.[0]).toBe("ab");
+    expect(re.lastIndex).toBe(6);
+    expect(re.exec("abxyab")).toBeNull();
+    expect(re.lastIndex).toBe(0);
+  });
+
+  it("sticky flag: lastIndex advances past the match so the next sticky exec uses the new position", () => {
+    const re = new PartialMatchRegExp(/ab/y);
+    expect(re.exec("abcd")?.[0]).toBe("ab");
+    expect(re.lastIndex).toBe(2);
+  });
+
+  it("global regex: exec respects an externally set lastIndex", () => {
+    const re = new PartialMatchRegExp(/ab/g);
+    re.exec("abxyab");
+    re.lastIndex = 0;
+    expect(re.exec("abxyab")).toMatchObject({ 0: "ab", index: 0 });
+    expect(re.lastIndex).toBe(2);
+  });
+
+  it("sticky regex: exec respects an externally set lastIndex", () => {
+    const re = new PartialMatchRegExp(/ab/y);
+    re.exec("abxyab");
+    re.lastIndex = 4;
+    expect(re.exec("abxyab")).toMatchObject({ 0: "ab", index: 4 });
+    expect(re.lastIndex).toBe(6);
+  });
+});
+
+[
+  // ── Literals ──────────────────────────────────────────────────────────────
+  { pattern: /^abc/, inputs: ["a", "ab", "abc", "xyz", "123", "!"] },
+  {
+    pattern: /^hello world/,
+    inputs: ["h", "he", "hel", "hello", "hello ", "hello world", "goodbye"]
+  },
+  // ── Character escapes ─────────────────────────────────────────────────────
+  { pattern: /^\x61\x62\x63/, inputs: ["a", "ab", "abc", "xyz"] },
+  { pattern: /^\u0061\u0062/, inputs: ["a", "ab", "xyz"] },
+  { pattern: /^\u{1F600}/u, inputs: ["😀", "xyz"] },
+  {
+    pattern: /^\p{Lowercase_Letter}+suffix/u,
+    inputs: ["a", "ab", "asuffix", "Asuffix", "1suffix"]
+  },
+  { pattern: /^\cj\cMsuffix/, inputs: ["\n", "\n\r", "\n\rsuffix", "x"] },
+  // ── Character classes ─────────────────────────────────────────────────────
+  { pattern: /^[a-z]+/, inputs: ["a", "ab", "A", "1"] },
+  {
+    pattern: /^[^abc]+suffix/,
+    inputs: ["x", "xy", "xysuffix", "asuffix", "bsuffix"]
+  },
+  { pattern: /^[ab\\]suffix/, inputs: ["a", "asuffix", "\\suffix", "csuffix"] },
+  {
+    pattern: /^[a-c]suffix/i,
+    inputs: ["A", "Asuffix", "Bsuffix", "Csuffix", "dsuffix"]
+  },
+  {
+    pattern: /^[a-z]+\s\w+/,
+    inputs: ["a", "ab", " ", "ab ", "ab c", "ab cd", "!", "123"]
+  },
+  // ── Disjunction ───────────────────────────────────────────────────────────
+  {
+    pattern: /^foo|^bar/,
+    inputs: ["f", "fo", "foo", "b", "ba", "bar", "xyz", "123", "!"]
+  },
+  { pattern: /^cat|^dog/, inputs: ["c", "ca", "cat", "d", "do", "dog", "xyz"] },
+  // ── Quantifiers ───────────────────────────────────────────────────────────
+  {
+    pattern: /^\d{3}-\d{4}/,
+    inputs: [
+      "1",
+      "12",
+      "123",
+      "123-",
+      "123-4",
+      "123-45",
+      "123-456",
+      "123-4567",
+      "xyz",
+      "!"
+    ]
+  },
+  { pattern: /^ab*c/, inputs: ["a", "ab", "abc", "abbc", "ac", "b", "axc"] },
+  { pattern: /^ab+c/, inputs: ["ab", "abc", "abbc", "a", "ac"] },
+  { pattern: /^ab?c/, inputs: ["a", "ab", "abc", "ac", "axc"] },
+  {
+    pattern: /^ab{2,4}c/,
+    inputs: ["ab", "abb", "abbb", "abbbb", "abbbbc", "abc", "abbbbbbc"]
+  },
+  { pattern: /^ab*?c/, inputs: ["a", "ab", "abc", "abbc", "ac", "axc"] },
+  // ── Unicode sets (v flag) ─────────────────────────────────────────────────
+  {
+    pattern: /^[\p{Alphabetic}]+suffix/v,
+    inputs: ["a", "aあ", "aあsuffix", "1suffix", "!suffix"]
+  },
+  // ── Modifiers ─────────────────────────────────────────────────────────────
+  {
+    pattern: /^(?i:abc)suffix/,
+    inputs: ["A", "AB", "ABC", "ABCsuffix", "abcsuffix", "xyz"]
+  },
+  {
+    pattern: /^(?-i:abc)suffix/i,
+    inputs: ["a", "ab", "abcsuffix", "ABCsuffix", "xyz"]
+  },
+  // ── Groups ────────────────────────────────────────────────────────────────
+  {
+    pattern: /^(foo)(bar)/,
+    inputs: ["f", "fo", "foo", "foob", "fooba", "foobar", "xyz"]
+  },
+  {
+    pattern: /^(?:foo)(bar)/,
+    inputs: ["f", "fo", "foo", "foob", "foobar", "xyz"]
+  },
+  {
+    pattern: /^(?<tag>foo)bar/,
+    inputs: ["f", "fo", "foo", "foob", "foobar", "xyz"]
+  },
+  {
+    pattern: /^(ab(cd)e)f/,
+    inputs: ["a", "ab", "abc", "abcd", "abcde", "abcdef", "xyz"]
+  },
+  // ── Lookahead assertions ──────────────────────────────────────────────────
+  {
+    pattern: /^foo(?=bar)/,
+    inputs: ["f", "fo", "foo", "foob", "foobar", "fox"]
+  },
+  {
+    pattern: /^foo(?!baz)/,
+    inputs: ["f", "fo", "foo", "foob", "foobaz", "foobar"]
+  },
+  // ── Lookbehind assertions ─────────────────────────────────────────────────
+  {
+    pattern: /(?<=foo)bar/,
+    inputs: ["b", "ba", "bar", "foob", "fooba", "foobar", "xbar"]
+  },
+  {
+    pattern: /(?<!foo)bar/,
+    inputs: ["b", "ba", "bar", "foob", "foobar", "xbar"]
+  },
+  // ── Boundary assertions ───────────────────────────────────────────────────
+  { pattern: /^foo$/, inputs: ["f", "fo", "foo", "foo ", "xfoo"] },
+  { pattern: /^\bfoo\b/, inputs: ["f", "fo", "foo", "foob", "xfoo"] },
+  { pattern: /^\Bfoo\B/, inputs: ["f", "fo", "foo", "xfooy", "xfoo"] },
+  // ── Multiline ─────────────────────────────────────────────────────────────
+  { pattern: /^foo$/m, inputs: ["f", "fo", "foo", "foo ", "foo\nbar"] }
+].forEach(({ pattern, inputs }) => {
+  it(`fast-path parity with createPartialMatchRegex: /${pattern.source}/${pattern.flags}`, () => {
+    const fast = new PartialMatchRegExp(pattern);
+    const ref = createPartialMatchRegex(pattern);
+    const originalMatchesEmpty = new RegExp(pattern.source, pattern.flags).test(
+      ""
+    );
+    for (const s of inputs) {
+      // PartialMatchRegExp suppresses sentinel matches (empty match at end-of-input)
+      // that createPartialMatchRegex exposes as ["", index: s.length, ...].
+      const m = ref.exec(s);
+      const expected =
+        m !== null &&
+        (m.index < s.length || (s.length === 0 && originalMatchesEmpty));
+      expect(fast.test(s)).toBe(expected);
+    }
+  });
+});
+
+describe("sentinel suppression — exec/test return null/false for non-matching inputs", () => {
+  it("test() returns false for a string that cannot match", () => {
+    const re = new PartialMatchRegExp(/^foo/);
+    expect(re.test("bar")).toBe(false);
+    expect(re.test("xyz")).toBe(false);
+    expect(re.test("foobar".slice(3))).toBe(false); // "bar"
+  });
+
+  it("exec() returns null for a string that cannot match", () => {
+    const re = new PartialMatchRegExp(/^foo/);
+    expect(re.exec("bar")).toBeNull();
+    expect(re.exec("xyz")).toBeNull();
+  });
+
+  it("valid prefixes are not suppressed", () => {
+    const re = new PartialMatchRegExp(/^foobar/);
+    expect(re.test("f")).toBe(true);
+    expect(re.test("fo")).toBe(true);
+    expect(re.test("foo")).toBe(true);
+    expect(re.test("foob")).toBe(true);
+    expect(re.test("fooba")).toBe(true);
+    expect(re.test("foobar")).toBe(true);
+  });
+
+  it("empty string returns false when the original pattern does not match empty", () => {
+    expect(new PartialMatchRegExp(/^foo/).test("")).toBe(false);
+    expect(new PartialMatchRegExp(/^[a-z]+/).test("")).toBe(false);
+  });
+
+  it("empty string returns true when the original pattern matches empty", () => {
+    expect(new PartialMatchRegExp(/^a*/).test("")).toBe(true);
+    expect(new PartialMatchRegExp(/^x?$/).test("")).toBe(true);
+    expect(new PartialMatchRegExp(/^$/).test("")).toBe(true);
+  });
+
+  it("string.match() returns null for non-matching input", () => {
+    const re = new PartialMatchRegExp(/^foo/);
+    expect("bar".match(re)).toBeNull();
+    expect("fo".match(re)).not.toBeNull();
+  });
+
+  it("global regex with non-zero lastIndex resets lastIndex to 0 after sentinel suppression", () => {
+    const re = new PartialMatchRegExp(/foo/g);
+    re.lastIndex = 1;
+    expect(re.exec("XXX")).toBeNull();
+    expect(re.lastIndex).toBe(0);
+  });
+
+  it("sticky regex resets lastIndex to 0 after sentinel suppression", () => {
+    const re = new PartialMatchRegExp(/foo/y);
+    re.lastIndex = 3;
+    expect(re.exec("XXX")).toBeNull();
+    expect(re.lastIndex).toBe(0);
+  });
+
+  it("global regex: test('') mirrors whether the original pattern matches empty", () => {
+    expect(new PartialMatchRegExp(/^a*/g).test("")).toBe(true);
+    expect(new PartialMatchRegExp(/^foo/g).test("")).toBe(false);
+  });
+
+  it("sticky regex: test('') mirrors whether the original pattern matches empty", () => {
+    expect(new PartialMatchRegExp(/^a*/y).test("")).toBe(true);
+    expect(new PartialMatchRegExp(/^foo/y).test("")).toBe(false);
+  });
+});

--- a/src/partialMatchRegExp.ts
+++ b/src/partialMatchRegExp.ts
@@ -9,7 +9,7 @@ export class PartialMatchRegExp extends RegExp {
     this._partial = createPartialMatchRegex(this);
     this._originalSticky = new RegExp(
       this.source,
-      this.flags.replace(/[gy]/, "") + "y"
+      this.flags.replace(/[gy]/g, "") + "y"
     );
   }
 
@@ -17,7 +17,7 @@ export class PartialMatchRegExp extends RegExp {
     const partial = this._partial;
     partial.lastIndex = this.lastIndex;
     const match = partial.exec(input);
-    if (match?.index === input.length) {
+    if (match?.[0].length === 0) {
       const originalSticky = this._originalSticky;
       originalSticky.lastIndex = match.index;
       const originalMatch = originalSticky.exec(input);

--- a/src/partialMatchRegExp.ts
+++ b/src/partialMatchRegExp.ts
@@ -1,0 +1,29 @@
+import createPartialMatchRegex from "./createPartialMatchRegex.ts";
+
+export class PartialMatchRegExp extends RegExp {
+  #partial: RegExp;
+  #originalMatchesEmpty: boolean;
+
+  constructor(pattern: RegExp | string, flags?: string) {
+    super(pattern, flags);
+    this.#partial = createPartialMatchRegex(this);
+    this.#originalMatchesEmpty = new RegExp(this.source, this.flags).test("");
+  }
+
+  override exec(input: string): RegExpExecArray | null {
+    const partial = this.#partial;
+    partial.lastIndex = this.lastIndex;
+    const match = partial.exec(input);
+    if (
+      match?.index === input.length &&
+      (input.length > 0 || !this.#originalMatchesEmpty)
+    ) {
+      if (this.global || this.sticky) this.lastIndex = 0;
+      return null;
+    }
+    this.lastIndex = partial.lastIndex;
+    return match;
+  }
+}
+
+export default PartialMatchRegExp;

--- a/src/partialMatchRegExp.ts
+++ b/src/partialMatchRegExp.ts
@@ -1,25 +1,30 @@
 import createPartialMatchRegex from "./createPartialMatchRegex.ts";
 
 export class PartialMatchRegExp extends RegExp {
-  #partial: RegExp;
-  #originalMatchesEmpty: boolean;
+  private _partial: RegExp;
+  private _originalSticky: RegExp;
 
   constructor(pattern: RegExp | string, flags?: string) {
     super(pattern, flags);
-    this.#partial = createPartialMatchRegex(this);
-    this.#originalMatchesEmpty = new RegExp(this.source, this.flags).test("");
+    this._partial = createPartialMatchRegex(this);
+    this._originalSticky = new RegExp(
+      this.source,
+      this.flags.replace(/[gy]/, "") + "y"
+    );
   }
 
   override exec(input: string): RegExpExecArray | null {
-    const partial = this.#partial;
+    const partial = this._partial;
     partial.lastIndex = this.lastIndex;
     const match = partial.exec(input);
-    if (
-      match?.index === input.length &&
-      (input.length > 0 || !this.#originalMatchesEmpty)
-    ) {
-      if (this.global || this.sticky) this.lastIndex = 0;
-      return null;
+    if (match?.index === input.length) {
+      const originalSticky = this._originalSticky;
+      originalSticky.lastIndex = match.index;
+      const originalMatch = originalSticky.exec(input);
+      if (originalMatch === null || originalMatch[0].length !== 0) {
+        if (this.global || this.sticky) this.lastIndex = 0;
+        return null;
+      }
     }
     this.lastIndex = partial.lastIndex;
     return match;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,8 +7,9 @@
   ],
   "include": ["src/**/*"],
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "outDir": "./lib",
-    "target": "es5",
+    "target": "ES2015",
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["ES2024"],
+    "lib": ["ESNext"],
     "types": ["vitest/globals"],
   },
   "include": ["src/**/*", "test/**/*", "eslint.config.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "rewriteRelativeImportExtensions": true,
     "target": "ES2024",
     "module": "ESNext",
+    "moduleDetection": "force",
     "moduleResolution": "bundler",
     "declaration": true,
     "outDir": "./lib",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
     "lib": ["ESNext"],
     "types": ["vitest/globals"],
   },
-  "include": ["src/**/*", "test/**/*", "eslint.config.ts"],
+  "include": ["src/**/*", "test/**/*", "eslint.config.ts", ".github/scripts/**/*.ts"],
   "exclude": ["node_modules", "lib"]
 }


### PR DESCRIPTION
# Issue

resolves #14 

## Details

Replace the `createPartialMatchRegex` default export with a `PartialMatchRegExp` class, to allow patching of the `.exec()` method, to provide more expected outcomes when partially marching expressions without terminating [input boundary assertions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Input_boundary_assertion).

This moves the minimum version to ES2015 from ES5, to allow `RegExp` subclassing that avoids trying to manually fix the prototype chain (or worse fiddle with `__proto__`), or move to composition (which would imply a larger test surface).

## Semantic Version Impact

- [ ] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [x] **MAJOR** - Breaking changes (not backwards compatible)

## Scout rule

- Add benchmarking workspace, to help track performance of new subclass
  - Added benchmarking workflow to CI, with temporary `fail-on-alert: false` whilst building a baseline
- Upgrade typescript
- Move from `.substring()` to `.slice()`
- Added parity tests against reference implementations
- Upgraded `actions/checkout` to [v7](https://github.com/actions/checkout/tree/v7)
- Upgraded `actions/github-script` to [v9](https://github.com/actions/github-script/tree/v9)
- Fixed test with UTF-16 code units to assert they match independently, properly

## CheckList

- [x] PR starts with [_ISSUE_ID_]
- [x] I have added an entry to the `[Unreleased]` section in `docs/CHANGELOG.md`
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
