### PR TITLE
[NO-ISSUE] various docs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The library has been stress-tested with various regular expression features in i
 Such combinations have not been tested.
 
 > [!NOTE]
-> See [Partial Match Parity](/docs/partial-match-parity.md) for full detail of how the library compares to reference implementations
+> See [Partial Match Parity](/docs/partial-match-parity.md) for full details on how the library compares to reference implementations
 
 ## Supported Features
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ The library has been stress-tested with various regular expression features in i
 
 Such combinations have not been tested.
 
+> [!NOTE]
+> See [Partial Match Parity](/docs/partial-match-parity.md) for full detail of how the library compares to reference implementations
+
 ## Supported Features
 
 - 🔤 [Literal characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Literal_character)
@@ -92,7 +95,6 @@ The following regex features are **not currently supported**:
 
 The library requires **ES2015** (ECMAScript 6) — the minimum JavaScript version that supports native extension of built-in types such as `RegExp`, which `PartialMatchRegExp` relies on to override `exec()`. Additionally, certain regular expression features require newer environments:
 
-- [**Unicode escapes**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape) (`\u{...}`)
 - [**Unicode property escapes**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape) (`\p{...}`, `\P{...}`) - ES2018+
 - [**Lookbehind assertions**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion) (`(?<=...)`, `(?<!...)`) - ES2018+
 - [**Named capturing groups**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group) (`(?<name>...)`) - ES2018+
@@ -102,25 +104,6 @@ The library requires **ES2015** (ECMAScript 6) — the minimum JavaScript versio
 - [**Modifiers**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Modifier) (`(?ims:...)`, `(?-ims:...)`, `(?i-ms:...)`) - ES2025+
 
 ## Caveats
-
-### [`.test()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) and empty-input behaviour
-
-The partial transform produces a pattern that can match an empty string at the end of input (via the `|$` sentinel). `PartialMatchRegExp` suppresses these sentinel matches — but only when the original pattern would not itself match at that position. This means:
-
-- inputs that the pattern genuinely matches (including patterns that match at end-of-input like `/$/`) return `true`
-- inputs where the sentinel fired only because the pattern ran off the end return `false`
-
-```js
-const re = new PartialMatchRegExp(/^foo/);
-re.test("bar"); // false — cannot match
-re.test("fo");  // true  — valid prefix
-re.test("foo"); // true  — full match
-re.test("");    // false — pattern does not accept empty string
-
-new PartialMatchRegExp(/$/).test("abc"); // true — $ genuinely matches end-of-input
-```
-
-`test("")` reflects whether the original pattern matches the empty string. Patterns like `/^a*/` or `/^$/` do accept `""`, so `test("")` returns `true` for those. Patterns that require at least one character return `false`.
 
 ### Backreferences
 
@@ -148,28 +131,34 @@ In [unicode-aware mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/
 
 ### [Sticky](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky) Flag (`y`)
 
-The **sticky flag may not behave as expected** in partial matching scenarios. The sticky flag requires matches to start at `lastIndex`, but a partial match failure resets `lastIndex` to 0. This means subsequent attempts cannot "continue" from where the previous match failed, making progressive character-by-character validation problematic.
-
-**Example:**
+The sticky flag is fully supported for its intended use case: **scanning within a single fixed string**. Partial matches are found only at `lastIndex`; the engine does not scan forward, and `lastIndex` advances on success or resets to `0` on failure — exactly as native sticky regexes behave.
 
 ```javascript
 import PartialMatchRegExp from "regex-partial-match";
 
 const partial = new PartialMatchRegExp(/hello/y);
 
-partial.lastIndex = 0;
-partial.test("h"); // succeeds, lastIndex advances
-partial.test("he"); // succeeds, but lastIndex was reset by previous test
-// Cannot reliably continue partial matching with sticky flag
+partial.lastIndex = 2;
+partial.test("xyhello"); // true  — partial match at position 2
+partial.test("xyworld"); // false — no match at position 2, no forward scan
+partial.lastIndex = 2;
+partial.test("xyhel");   // true  — partial prefix "hel" at position 2
 ```
 
-**Recommendation:** Avoid using the `y` flag with partial matching unless you fully understand the implications.
+**Limitation — progressive input validation:** Because a successful match advances `lastIndex`, testing a sequence of growing strings against the same instance does not work as expected:
 
-### Global Flag (`g`)
+```javascript
+const partial = new PartialMatchRegExp(/hello/y);
 
-The **global flag is preserved** but may not be necessary for partial matching use cases. The `g` flag affects behaviour when using `.exec()` repeatedly to find all matches, but partial matching typically validates a single prefix at a time.
+partial.test("h");   // true,  lastIndex → 1
+partial.test("he");  // false — sticky requires a match at position 1 of "he",
+                     //         but "e" is not a valid start of the pattern
+partial.test("hel"); // true (lastIndex was reset to 0 by the previous failure)
+```
 
-The global flag does not cause issues like the sticky flag, as partial patterns naturally match from the beginning of the input. However, if you're using `lastIndex` to track position, be aware that failed matches will reset it to 0.
+There is no way for the subclass to distinguish "scanning forward in the same string" from "testing a new, longer string", so this cannot be fixed in code. For progressive input validation, use a regex **without** the `y` flag and always test against the full input so far.
+
+The `gy` flag combination is also fully supported: `exec()`/`test()` behave as sticky, while `match()`, `matchAll()`, `replace()`, and `replaceAll()` iterate via `exec()` as global — matching [the language specification](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky).
 
 ### "String properties"
 
@@ -186,7 +175,9 @@ In [`v` mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/
 ```javascript
 import PartialMatchRegExp from "regex-partial-match";
 
-const partial = new PartialMatchRegExp(/^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/i);
+const partial = new PartialMatchRegExp(
+  /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/i
+);
 
 function validateEmail(input) {
   return partial.test(input) ? "valid" : "invalid";
@@ -288,89 +279,6 @@ Algorithm created by [Lucas Trzesniewski](https://github.com/ltrzesniewski).
 
 Contributions are welcome! Please open an issue or pull request on [GitHub](https://github.com/TomStrepsil/regex-partial-match).
 
-## Compatibility with other partial-match implementations
-
-Several widely-used regex libraries offer native partial-match support. This section maps their concepts and test cases to this library's behaviour.
-
-> **Provenance note:** The parity tests added in `src/createPartialMatchRegex.test.ts` ("parity with reference implementations") vary in how directly they reflect each source:
-> - **JDK** — test cases are explicit: the `hitEndTest`, `caretAtEndTest`, and `wordSearchTest` methods in `RegExTest.java` name specific patterns and inputs (e.g. `/^squidattack/` on `"squid"` / `"squack"`, `/^x?/m` on `"\r"`, `/\b/` on `"word1 word2 word3"`), which are reproduced directly.
-> - **Lucene** — test cases are derived: `TestRegExp.java` describes what each test method exercises (patterns like `[^y]*{1,2}`, `"(a)|".repeat(50000)`, and character sets σ/Σ/ῼ/ﬗ), but the specific assertions in the test suite here are our own translations of those properties.
-> - **RE2** — test cases are conceptual only: `tester.cc` and `exhaustive_tester.cc` implement a parametric consistency framework (NFA/DFA/backtracking agreement), not a fixed set of `(pattern, input, expected)` tuples. The RE2 rows below document semantic alignment rather than quoting specific test cases.
-
-### Apache Lucene (`TestRegExp.java`)
-
-Lucene implements partial matching via a deterministic finite automaton (DFA). Parity tests are **derived** from the described behaviour of each test method — not direct quotations of Lucene assertions.
-
-Lucene's automaton-based regex dialect **cannot express backreferences** (finite automata cannot represent them). `TestRegExp.java` contains no backreference tests.
-
-| Lucene test method | Property tested | This library |
-|---|---|---|
-| `testSmoke` | Basic grouping — `a(b+|c+)d` matches `abbbbbd`, `acd`; rejects `ad` | ✅ Covered — quantifiers, groups, disjunctions |
-| `testUnicodeAsciiInsensitiveFlags` | Unicode case folding — `σ`/`Σ`, `ῼ`, `ﬗ` | ✅ Covered — `i` + `u` flags delegate to JS Unicode case folding |
-| `testRepeatWithEmptyString` | Quantifiers over empty-matching sub-expressions — `[^y]*{1,2}` | ✅ Covered — `a*suffix`, `a?suffix`, `^[^y]*suffix` |
-| `testRegExpNoStackOverflow` | Deep nesting / stack safety — `(a)|` × 50 000 | ✅ Covered — wide alternation (× 1 000) and deeply nested groups (depth 100) |
-| `testCoreJavaParity` | 2 000 random expressions validated against `java.util.regex.Pattern` | ✅ Covered structurally — every prefix of every pattern is tested |
-| Backreferences | Not in scope — unsupported by the automaton dialect | See `PartialMatchRegExp` below |
-
-### Google RE2 (`tester.cc`, `exhaustive_tester.cc`)
-
-RE2 exposes partial matching via `UNANCHORED` mode (match anywhere in the string) versus `ANCHOR_BOTH` (full-string match). `tester.cc` and `exhaustive_tester.cc` implement a parametric testing framework that validates NFA, DFA, and backtracking engines against each other across exhaustively-generated patterns — there are **no fixed `(pattern, input, expected)` test cases to quote**. Parity is therefore assessed **conceptually** against RE2's semantics.
-
-RE2 **explicitly excludes backreferences by design**. From `re2.h`: *"backreferences and generalized assertions are not available"*. This is a deliberate trade-off to guarantee linear-time matching; there are therefore no backreference tests anywhere in RE2's test suite.
-
-| RE2 concept | This library |
-|---|---|
-| `UNANCHORED` — match substring anywhere | ✅ Use the pattern without `^`/`$` anchors |
-| `ANCHOR_START` — match from beginning | ✅ Use `^` anchor |
-| `ANCHOR_BOTH` — full-string match | ✅ Use `^…$` anchors |
-| First-match (NFA) vs longest-match (POSIX) semantics | ✅ ECMAScript / NFA first-match — `(a\|aa)\1` on `"aaaa"` yields `m[1]="a"`, not `"aa"` |
-| Capturing groups across anchoring modes | ✅ Covered — see groups tests |
-| Backreferences | Not in scope — excluded by design | See `PartialMatchRegExp` below |
-| Multi-engine consistency | N/A — JS has a single engine per runtime |
-
-### OpenJDK (`java.util.regex` — `RegExTest.java`)
-
-Java expresses partial matching through `Matcher.hitEnd()`, `Matcher.lookingAt()`, and `Matcher.find()`. Parity tests are **explicit**: the specific patterns and strings below are taken directly from named test methods in `RegExTest.java`.
-
-The JDK **does** support backreferences, and `RegExTest.java` includes `backRefTest()` (~line 2520) and `ciBackRefTest()` (~line 2568) for numeric backreferences with `find()`. However, **neither method combines backreferences with `hitEnd()` or any other partial-match concept** — they test full-match correctness only. There are no JDK tests for the behaviour of `hitEnd()` on patterns containing backreferences.
-
-| JDK test method / concept | Specific case | This library equivalent |
-|---|---|---|
-| `hitEndTest` (lines 545–588) | `/^squidattack/` on `"squid"` → `hitEnd=true` | `exec("squid")[0] === "squid"` (non-empty = prefix found) |
-| `hitEndTest` | `/^squidattack/` on `"squack"` → `hitEnd=false` | `exec("squack") === null` (anchored, diverges early) |
-| `hitEndTest` | `/^abc/` on `"ab"` → `hitEnd=true` | `exec("ab")[0] === "ab"` |
-| `hitEndTest` | `/^abc/` on `"ad"` → `hitEnd=false` | `exec("ad") === null` |
-| `hitEndTest` | `/catattack/` on `"attackattackattackcatatta"` → `hitEnd=true` | `exec(...)[0] !== ""` |
-| `caretAtEndTest` (lines 506–513) | `/^x?/m` on `"\r"` — successive `find()` calls | First match at index 0; second (after manual `lastIndex++`) at index 1 |
-| `wordSearchTest` (lines 483–503) | `/\b/` on `"word1 word2 word3"` with progressive `find(pos)` | `\bwor` with `g` flag and progressive `lastIndex` — finds matches at 0, 6, 12 |
-| `backRefTest` (~line 2520) | `(a*)bc\1`, `(abc)(def)\1` — full match via `find()` | Full match only; no partial-match equivalent in the JDK test |
-| `ciBackRefTest` (~line 2568) | Same patterns with `(?i)` case-insensitive flag | Full match only; no partial-match equivalent in the JDK test |
-| `Matcher.hitEnd()` | Semantic: did the engine exhaust input? | `exec(input)[0] !== ""` — non-empty result means valid prefix |
-| `Matcher.lookingAt()` | Prefix match from start | `exec` with `^` anchor |
-| `Matcher.matches()` | Full-string match | `exec` with `^…$` anchors |
-| `Matcher.find()` | Next substring match | `exec` on a `g`-flagged regex, advancing `lastIndex` |
-| `Matcher.find(pos)` | Match from a given position | Set `lastIndex` before calling `exec` |
-| `Matcher.requireEnd()` | More input could invalidate a current match | No direct equivalent; patterns ending with `$` or `\b` exhibit this — not explicitly exposed |
-
-### Summary
-
-| Feature | Lucene | RE2 | JDK | This library |
-|---|:---:|:---:|:---:|:---:|
-| Literal prefix matching | ✅ | ✅ | ✅ | ✅ |
-| Character classes | ✅ | ✅ | ✅ | ✅ |
-| Quantifiers (including zero-match) | ✅ | ✅ | ✅ | ✅ |
-| Disjunctions | ✅ | ✅ | ✅ | ✅ |
-| Groups (capturing, non-capturing, named) | ✅ | ✅ | ✅ | ✅ |
-| Lookahead / lookbehind | — | ✅ | ✅ | ✅ |
-| Unicode case folding | ✅ | ✅ | ✅ | ✅ (`i`+`u` flags) |
-| Deep nesting / stack safety | ✅ | ✅ | ✅ | ✅ |
-| Anchored full match | ✅ | ✅ | ✅ (`matches()`) | ✅ (`^…$`) |
-| Unanchored substring match | ✅ | ✅ | ✅ (`find()`) | ✅ (no anchor) |
-| hitEnd() / prefix-only match | — | — | ✅ | ✅ (non-empty exec result) |
-| requireEnd() | — | — | ✅ | ⚠️ Not exposed |
-| Backreference partial matching | ❌ unsupported dialect | ❌ excluded by design | ⚠️ full match only (`backRefTest`) | ❌ cannot partially match (atomic) |
-| Multi-engine consistency | — | ✅ | — | N/A |
-
 ## Related projects
 
 | Project                                                                                     | Description                                                                                                                                                                          |
@@ -381,4 +289,4 @@ The JDK **does** support backreferences, and `RegExTest.java` includes `backRefT
 | [`@eslint-community/regexpp`](https://github.com/eslint-community/regexpp)                  | A regular expression parser for ECMAScript with AST generation and visitor implementation                                                                                            |
 | [`Regex+`](https://www.npmjs.com/package/regex)                                             | template literal, transforming native regular expressions                                                                                                                            |
 | [`Awesome Regex`](https://github.com/slevithan/awesome-regex)                               | Curated list of tools, tutorials, libraries, and other resources, covering all major regex flavours                                                                                  |
-| [`replace-content-transformer`](https://github.com/TomStrepsil/replace-content-transformer) | A toolkit for stream content replacement, underpinned by `regex-partial-match`                                                                                                                                                                                 |
+| [`replace-content-transformer`](https://github.com/TomStrepsil/replace-content-transformer) | A toolkit for stream content replacement, underpinned by `regex-partial-match`                                                                                                       |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed errant CHANGELOG version for v[0.1.8](#018---2025-12-08)
 - Added missing tests for wildcard expressions
 - Fixed test with UTF-16 code units to assert they match independently, properly
+- Corrected documentation on `y` and `g` flags
 
 ### Changed
 

--- a/docs/partial-match-parity.md
+++ b/docs/partial-match-parity.md
@@ -16,7 +16,7 @@ Lucene's automaton-based regex dialect **cannot express backreferences** (finite
 
 | Lucene test method                 | Property tested                                                      | This library                                                      |
 | ---------------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------- | 
-| `testSmoke`                        | Basic grouping — `a(b+\|c+)d`matches`abbbbbd`, `acd`; rejects `ad`   | ✅ Covered — quantifiers, groups, disjunctions                     |
+| `testSmoke`                        | Basic grouping — `a(b+\|c+)d` matches `abbbbbd`, `acd`; rejects `ad`   | ✅ Covered — quantifiers, groups, disjunctions                     |
 | `testUnicodeAsciiInsensitiveFlags` | Unicode case folding — `σ`/`Σ`, `ῼ`, `ﬗ`                            | ✅ Covered — `i` + `u` flags delegate to JS Unicode case folding  |
 | `testRepeatWithEmptyString`        | Quantifiers over empty-matching sub-expressions — `[^y]*{1,2}`       | ✅ Covered — `a*suffix`, `a?suffix`, `^[^y]*suffix`               |
 | `testRegExpNoStackOverflow`        | Deep nesting / stack safety — `(a)` × 50 000                         | ✅ Covered — wide alternation (× 1 000) and deeply nested groups (depth 100) |

--- a/docs/partial-match-parity.md
+++ b/docs/partial-match-parity.md
@@ -1,0 +1,84 @@
+# Partial Match Parity
+
+Several widely-used regex libraries offer native partial-match support. This document maps their concepts and test cases to this library's behaviour.
+
+> [!NOTE]
+> The parity tests added in `src/createPartialMatchRegex.test.ts` ("parity with reference implementations") vary in how directly they reflect each source:
+>
+> - **JDK** — test cases are explicit: the `hitEndTest`, `caretAtEndTest`, and `wordSearchTest` methods in `RegExTest.java` name specific patterns and inputs (e.g. `/^squidattack/` on `"squid"` / `"squack"`, `/^x?/m` on `"\r"`, `/\b/` on `"word1 word2 word3"`), which are reproduced directly.
+> - **Lucene** — test cases are derived: `TestRegExp.java` describes what each test method exercises (patterns like `[^y]*{1,2}`, `"(a)|".repeat(50000)`, and character sets σ/Σ/ῼ/ﬗ), but the specific assertions in the test suite here are our own translations of those properties.
+> - **RE2** — test cases are conceptual only: `tester.cc` and `exhaustive_tester.cc` implement a parametric consistency framework (NFA/DFA/backtracking agreement), not a fixed set of `(pattern, input, expected)` tuples. The RE2 rows below document semantic alignment rather than quoting specific test cases.
+
+## Apache Lucene (`TestRegExp.java`)
+
+Lucene implements partial matching via a deterministic finite automaton (DFA). Parity tests are **derived** from the described behaviour of each test method — not direct quotations of Lucene assertions.
+
+Lucene's automaton-based regex dialect **cannot express backreferences** (finite automata cannot represent them). `TestRegExp.java` contains no backreference tests.
+
+| Lucene test method                 | Property tested                                                      | This library                                                      |
+| ---------------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------- | 
+| `testSmoke`                        | Basic grouping — `a(b+\|c+)d`matches`abbbbbd`, `acd`; rejects `ad`   | ✅ Covered — quantifiers, groups, disjunctions                     |
+| `testUnicodeAsciiInsensitiveFlags` | Unicode case folding — `σ`/`Σ`, `ῼ`, `ﬗ`                            | ✅ Covered — `i` + `u` flags delegate to JS Unicode case folding  |
+| `testRepeatWithEmptyString`        | Quantifiers over empty-matching sub-expressions — `[^y]*{1,2}`       | ✅ Covered — `a*suffix`, `a?suffix`, `^[^y]*suffix`               |
+| `testRegExpNoStackOverflow`        | Deep nesting / stack safety — `(a)` × 50 000                         | ✅ Covered — wide alternation (× 1 000) and deeply nested groups (depth 100) |
+| `testCoreJavaParity`               | 2 000 random expressions validated against `java.util.regex.Pattern` | ✅ Covered structurally — every prefix of every pattern is tested |
+| Backreferences                     | Not in scope — unsupported by the automaton dialect                  | See `PartialMatchRegExp` below                                    |
+
+## Google RE2 (`tester.cc`, `exhaustive_tester.cc`)
+
+RE2 exposes partial matching via `UNANCHORED` mode (match anywhere in the string) versus `ANCHOR_BOTH` (full-string match). `tester.cc` and `exhaustive_tester.cc` implement a parametric testing framework that validates NFA, DFA, and backtracking engines against each other across exhaustively-generated patterns — there are **no fixed `(pattern, input, expected)` test cases to quote**. Parity is therefore assessed **conceptually** against RE2's semantics.
+
+RE2 **explicitly excludes backreferences by design**. From `re2.h`: _"backreferences and generalized assertions are not available"_. This is a deliberate trade-off to guarantee linear-time matching; there are therefore no backreference tests anywhere in RE2's test suite.
+
+| RE2 concept                                          | This library                                                                            |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `UNANCHORED` — match substring anywhere              | ✅ Use the pattern without `^`/`$` anchors                                              |
+| `ANCHOR_START` — match from beginning                | ✅ Use `^` anchor                                                                       |
+| `ANCHOR_BOTH` — full-string match                    | ✅ Use `^…$` anchors                                                                    |
+| First-match (NFA) vs longest-match (POSIX) semantics | ✅ ECMAScript / NFA first-match — `(a\|aa)\1` on `"aaaa"` yields `m[1]="a"`, not `"aa"` |
+| Capturing groups across anchoring modes              | ✅ Covered — see groups tests                                                           |
+| Backreferences                                       | ⚠️ full match only                                                                      |
+| Multi-engine consistency                             | N/A — JS has a single engine per runtime                                                |
+
+## OpenJDK (`java.util.regex` — `RegExTest.java`)
+
+Java expresses partial matching through `Matcher.hitEnd()`, `Matcher.lookingAt()`, and `Matcher.find()`. Parity tests are **explicit**: the specific patterns and strings below are taken directly from named test methods in `RegExTest.java`.
+
+The JDK **does** support backreferences, and `RegExTest.java` includes `backRefTest()` (~line 2520) and `ciBackRefTest()` (~line 2568) for numeric backreferences with `find()`. However, **neither method combines backreferences with `hitEnd()` or any other partial-match concept** — they test full-match correctness only. There are no JDK tests for the behaviour of `hitEnd()` on patterns containing backreferences.
+
+| JDK test method / concept        | Specific case                                                  | This library equivalent                                                                      |
+| -------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `hitEndTest` (lines 545–588)     | `/^squidattack/` on `"squid"` → `hitEnd=true`                  | `exec("squid")[0] === "squid"` (non-empty = prefix found)                                    |
+| `hitEndTest`                     | `/^squidattack/` on `"squack"` → `hitEnd=false`                | `exec("squack") === null` (anchored, diverges early)                                         |
+| `hitEndTest`                     | `/^abc/` on `"ab"` → `hitEnd=true`                             | `exec("ab")[0] === "ab"`                                                                     |
+| `hitEndTest`                     | `/^abc/` on `"ad"` → `hitEnd=false`                            | `exec("ad") === null`                                                                        |
+| `hitEndTest`                     | `/catattack/` on `"attackattackattackcatatta"` → `hitEnd=true` | `exec(...)[0] !== ""`                                                                        |
+| `caretAtEndTest` (lines 506–513) | `/^x?/m` on `"\r"` — successive `find()` calls                 | First match at index 0; second (after manual `lastIndex++`) at index 1                       |
+| `wordSearchTest` (lines 483–503) | `/\b/` on `"word1 word2 word3"` with progressive `find(pos)`   | `\bwor` with `g` flag and progressive `lastIndex` — finds matches at 0, 6, 12                |
+| `backRefTest` (~line 2520)       | `(a*)bc\1`, `(abc)(def)\1` — full match via `find()`           | Full match only; no partial-match equivalent in the JDK test                                 |
+| `ciBackRefTest` (~line 2568)     | Same patterns with `(?i)` case-insensitive flag                | Full match only; no partial-match equivalent in the JDK test                                 |
+| `Matcher.hitEnd()`               | Semantic: did the engine exhaust input?                        | `exec(input)[0] !== ""` — non-empty result means valid prefix                                |
+| `Matcher.lookingAt()`            | Prefix match from start                                        | `exec` with `^` anchor                                                                       |
+| `Matcher.matches()`              | Full-string match                                              | `exec` with `^…$` anchors                                                                    |
+| `Matcher.find()`                 | Next substring match                                           | `exec` on a `g`-flagged regex, advancing `lastIndex`                                         |
+| `Matcher.find(pos)`              | Match from a given position                                    | Set `lastIndex` before calling `exec`                                                        |
+| `Matcher.requireEnd()`           | More input could invalidate a current match                    | No direct equivalent; patterns ending with `$` or `\b` exhibit this — not explicitly exposed |
+
+## Summary
+
+| Feature                                  |         Lucene         |          RE2          |                JDK                 |        This library        |
+| ---------------------------------------- | :--------------------: | :-------------------: | :--------------------------------: | :------------------------: |
+| Literal prefix matching                  |           ✅           |          ✅           |                 ✅                 |             ✅             |
+| Character classes                        |           ✅           |          ✅           |                 ✅                 |             ✅             |
+| Quantifiers (including zero-match)       |           ✅           |          ✅           |                 ✅                 |             ✅             |
+| Disjunctions                             |           ✅           |          ✅           |                 ✅                 |             ✅             |
+| Groups (capturing, non-capturing, named) |           ✅           |          ✅           |                 ✅                 |             ✅             |
+| Lookahead / lookbehind                   |           —            |          ✅           |                 ✅                 |             ✅             |
+| Unicode case folding                     |           ✅           |          ✅           |                 ✅                 |     ✅ (`i`+`u` flags)     |
+| Deep nesting / stack safety              |           ✅           |          ✅           |                 ✅                 |             ✅             |
+| Anchored full match                      |           ✅           |          ✅           |          ✅ (`matches()`)          |         ✅ (`^…$`)         |
+| Unanchored substring match               |           ✅           |          ✅           |           ✅ (`find()`)            |       ✅ (no anchor)       |
+| hitEnd() / prefix-only match             |           —            |           —           |                 ✅                 | ✅ (non-empty exec result) |
+| requireEnd()                             |           —            |           —           |                 ✅                 |       ⚠️ Not exposed       |
+| Backreference partial matching           | ❌ unsupported dialect | ❌ excluded by design | ⚠️ full match only (`backRefTest`) |     ⚠️ full match only     |
+| Multi-engine consistency                 |           —            |          ✅           |                 —                  |            N/A             |

--- a/docs/partial-match-parity.md
+++ b/docs/partial-match-parity.md
@@ -2,12 +2,11 @@
 
 Several widely-used regex libraries offer native partial-match support. This document maps their concepts and test cases to this library's behaviour.
 
-> [!NOTE]
-> The parity tests added in `src/createPartialMatchRegex.test.ts` ("parity with reference implementations") vary in how directly they reflect each source:
->
-> - **JDK** — test cases are explicit: the `hitEndTest`, `caretAtEndTest`, and `wordSearchTest` methods in `RegExTest.java` name specific patterns and inputs (e.g. `/^squidattack/` on `"squid"` / `"squack"`, `/^x?/m` on `"\r"`, `/\b/` on `"word1 word2 word3"`), which are reproduced directly.
-> - **Lucene** — test cases are derived: `TestRegExp.java` describes what each test method exercises (patterns like `[^y]*{1,2}`, `"(a)|".repeat(50000)`, and character sets σ/Σ/ῼ/ﬗ), but the specific assertions in the test suite here are our own translations of those properties.
-> - **RE2** — test cases are conceptual only: `tester.cc` and `exhaustive_tester.cc` implement a parametric consistency framework (NFA/DFA/backtracking agreement), not a fixed set of `(pattern, input, expected)` tuples. The RE2 rows below document semantic alignment rather than quoting specific test cases.
+The parity tests added in `src/createPartialMatchRegex.test.ts` ("parity with reference implementations") vary in how directly they reflect each source:
+
+- **JDK** — test cases are explicit: the `hitEndTest`, `caretAtEndTest`, and `wordSearchTest` methods in `RegExTest.java` name specific patterns and inputs (e.g. `/^squidattack/` on `"squid"` / `"squack"`, `/^x?/m` on `"\r"`, `/\b/` on `"word1 word2 word3"`), which are reproduced directly.
+- **Lucene** — test cases are derived: `TestRegExp.java` describes what each test method exercises (patterns like `[^y]*{1,2}`, `"(a)|".repeat(50000)`, and character sets σ/Σ/ῼ/ﬗ), but the specific assertions in the test suite here are our own translations of those properties.
+- **RE2** — test cases are conceptual only: `tester.cc` and `exhaustive_tester.cc` implement a parametric consistency framework (NFA/DFA/backtracking agreement), not a fixed set of `(pattern, input, expected)` tuples. The RE2 rows below document semantic alignment rather than quoting specific test cases.
 
 ## Apache Lucene (`TestRegExp.java`)
 


### PR DESCRIPTION
## Details

- Update `README.md` to remove caveat regarding `.test()`, resolved by https://github.com/TomStrepsil/regex-partial-match/pull/40
- Move reference implementation parity to separate document
- Fixup Github-flavoured-markdown [alert](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts)
- Remove "unicode escapes" from the ES2015 gaps, since moved to that base in https://github.com/TomStrepsil/regex-partial-match/pull/40

## Semantic Version Impact

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## CheckList

- [ ] PR starts with [_ISSUE_ID_]
- [x] I have added an entry to the `[Unreleased]` section in `docs/CHANGELOG.md`
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
