### PR TITLE
[45] Fix for literal \k escapes, where no named capture group specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The library requires **ES2015** (ECMAScript 6) — the minimum JavaScript versio
 
 Fixed-length patterns like `/(abc)\1/` could theoretically become `/(?:(a)|$)(?:(b)|$)(?:(c)|$)(?:\1|$)(?:\2|$)(?:\3|$)/` (accepting polluted capture indexes as a side-effect), but this doesn't work for variable-length captures.
 
+In a pattern with no named capturing groups, [Annex B](https://tc39.es/ecma262/#sec-regular-expressions-patterns) tolerates `\k<a>` as the literal characters `k<a>`, but this is still treated as if it were a named backreference and matched atomically — `"k"` and `"k<"` will not partially match. A `\k` not immediately followed by a well-formed `<name>` reference is treated as the literal `k` and partially matches as usual.
+
 [^1]: To remain lightweight, no runtime type validation is applied, so non-typescript consumers will be reliant on underlying errors thrown, if used incorrectly.
 
 ### Positive Lookbehinds

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed test with UTF-16 code units to assert they match independently, properly
 - Corrected documentation on `y` and `g` flags
 - Fixed occurrences-quantifier probing so literal braces are not misinterpreted when a later quantifier appears
+- Fixed fatal out-of-memory crash when constructing from patterns containing `\k` without a closing `>`, which is a literal `k` per [Annex B](https://tc39.es/ecma262/#sec-regular-expressions-patterns) semantics, and ensured a `\k` not immediately followed by `<` is treated as that literal escape rather than fused with pattern text up to any later `>`
 
 ### Changed
 

--- a/src/createPartialMatchRegex.test.ts
+++ b/src/createPartialMatchRegex.test.ts
@@ -1541,5 +1541,27 @@ c`)
         }
       });
     });
+
+    // https://tc39.es/ecma262/#sec-regular-expressions-patterns
+    describe("Annex B literal \\k escapes", () => {
+      it("should tolerate \\k escapes with no named group reference to complete them", () => {
+        const partial = createPartialMatchRegex(new RegExp("\\k"));
+        expect(partial.exec("k")).toMatchAt({ match: "k", index: 0 });
+      });
+
+      it("should support partial matching of \\k escapes followed by an unterminated reference opening", () => {
+        const partial = createPartialMatchRegex(new RegExp("\\k<suffix"));
+        expect(partial).toMatchPartially({
+          characters: ["k", "<", ..."suffix".split("")]
+        });
+      });
+
+      it("should support partial matching of \\k escapes when a closing angle bracket appears later in the pattern", () => {
+        const partial = createPartialMatchRegex(new RegExp("\\ka>b"));
+        expect(partial).toMatchPartially({
+          characters: ["k", "a", ">", "b"]
+        });
+      });
+    });
   });
 });

--- a/src/createPartialMatchRegex.ts
+++ b/src/createPartialMatchRegex.ts
@@ -30,7 +30,9 @@ const createPartialMatchRegex = (regex: RegExp): RegExp => {
               appendOptional(3);
               break;
             case "k":
-              appendOptional(source.indexOf(">", i) - i + 1);
+              const referenceEnd =
+                source[i + 2] === "<" ? source.indexOf(">", i) : -1;
+              appendOptional(referenceEnd === -1 ? 2 : referenceEnd - i + 1);
               break;
             case "u":
               if (isUnicode && source[i + 2] === "{") {


### PR DESCRIPTION
# Issue

resolves #45

## Details

Constructing a partial-match regex from a pattern containing `\k` without a well-formed named group reference entered an infinite loop and crashed the process with a fatal, uncatchable out-of-memory error. `source.indexOf(">", i)` returns `-1` when no terminator exists, producing a slice length of `-i` that rewinds `i` to `0` and appends empty optional groups forever.

Such patterns are only constructible as native regexes when no named groups are present, in which case [Annex B](https://tc39.es/ecma262/#sec-regular-expressions-patterns) tolerates `\k` as a literal `k`. The transform now only scans for a closing `>` when `<` immediately follows `\k`, and otherwise falls back to a standard two-character escape. This covers both the crash (`/\k/`, `/\k</`, `/\k<a/`) and a subtler fusion bug where a `\k` with an unrelated `>` later in the pattern swallowed the intervening literals into one atom, so valid prefixes returned `null`:

```javascript
createPartialMatchRegex(/\k/);    // /(?:\k|$)/ — previously a fatal OOM crash
createPartialMatchRegex(/\ka>b/); // /(?:\k|$)(?:a|$)(?:>|$)(?:b|$)/ — previously /(?:\ka>|$)(?:b|$)/, so "k"/"ka" did not match
```

New tests live in an "Annex B literal `\k` escapes" describe: toleration of a lone `\k`, partial matching past an unterminated reference opening (`\k<suffix`), and partial matching when a closing angle bracket appears later in the pattern (`\ka>b`).

`README.md` has an addition under Caveats → Backreferences noting the residual atomic case — in a pattern with no named groups, `\k<a>` is natively the literal characters `k<a>` but is still matched atomically like a named backreference, so `"k"`/`"k<"` will not partially match.

## Semantic Version Impact

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## CheckList

- [x] PR starts with [45]
- [x] I have added an entry to the `[Unreleased]` section in `docs/CHANGELOG.md`
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
