### PR TITLE
[46] Support [ literal inside character class where not a v-mode (unicodeSets) expression.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrected documentation on `y` and `g` flags
 - Fixed occurrences-quantifier probing so literal braces are not misinterpreted when a later quantifier appears
 - Fixed fatal out-of-memory crash when constructing from patterns containing `\k` without a closing `>`, which is a literal `k` per [Annex B](https://tc39.es/ecma262/#sec-regular-expressions-patterns) semantics, and ensured a `\k` not immediately followed by `<` is treated as that literal escape rather than fused with pattern text up to any later `>`
+- Fixed character class scanning outside `v` (unicodeSets) mode to treat `[` as a literal character, ending the class at the first unescaped `]` instead of extending past the class boundary
 
 ### Changed
 

--- a/src/createPartialMatchRegex.test.ts
+++ b/src/createPartialMatchRegex.test.ts
@@ -244,6 +244,11 @@ describe("regexp-partial-match", () => {
         suffix: " including escaped square brackets"
       },
       {
+        input: /[a[b]suffix/,
+        chars: ["a", "[", "b"],
+        suffix: " including literal opening brackets, outside unicodeSets mode"
+      },
+      {
         input: /[ab\\]suffix/,
         chars: ["a", "b", "\\"],
         suffix: " including escaped backslashes"
@@ -465,6 +470,17 @@ describe("regexp-partial-match", () => {
       const input = /[a-c]suffix/;
       const partial = createPartialMatchRegex(input);
       expect(partial.exec("dsuf")).toNotMatch();
+    });
+
+    it("should end the class at the first unescaped closing bracket outside unicodeSets mode, treating subsequent brackets as literal characters", () => {
+      const input = /[a[b]c]/;
+      const partial = createPartialMatchRegex(input);
+      expect(partial).toMatchPartially({
+        characters: ["a", "c", "]"]
+      });
+      expect(partial.exec("ac]")).toMatchAt({ match: "ac]", index: 0 });
+      expect(partial.exec("bc]")).toMatchAt({ match: "bc]", index: 0 });
+      expect(partial.exec("[c]")).toMatchAt({ match: "[c]", index: 0 });
     });
   });
 

--- a/src/createPartialMatchRegex.ts
+++ b/src/createPartialMatchRegex.ts
@@ -82,7 +82,7 @@ const createPartialMatchRegex = (regex: RegExp): RegExp => {
                 escaped = !escaped;
                 continue;
               case "[":
-                if (!escaped) depth++;
+                if (!escaped && regex.unicodeSets) depth++;
                 break;
               case "]":
                 if (!escaped) depth--;


### PR DESCRIPTION
# Issue

resolves #46

## Details

The character class scanner unconditionally incremented nesting depth on every unescaped `[`, but bracket nesting only exists under the `v` (unicodeSets) flag. 

Outside `v` mode, `[` inside a class is a literal character and the class ends at the first unescaped `]`. The scanner therefore extended past the real class boundary, fusing following atoms into the class:

```javascript
const partial = createPartialMatchRegex(/[a[b]c]/); // class is [a[b], then literal c, then literal ]
partial.exec("ac]"); // "ac]" at 0 — worked before
partial.exec("ac");  // was null, now "ac" at 0
partial.exec("a");   // was null, now "a" at 0
```

Worse, valid patterns whose class contains a literal `[` with no matching later `]` (e.g. `/[a[b]suffix/`) sent the scanner into an infinite loop, hanging construction.

The fix gates the depth increment on `regex.unicodeSets`, so `v`-mode nested classes (which the existing unicode-sets suite covers extensively) are unaffected.

## Semantic Version Impact

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## CheckList

- [x] PR starts with [46]
- [x] I have added an entry to the `[Unreleased]` section in `docs/CHANGELOG.md`
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
