### PR TITLE
[47] Fix for astral plane characters outside of character classes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed occurrences-quantifier probing so literal braces are not misinterpreted when a later quantifier appears
 - Fixed fatal out-of-memory crash when constructing from patterns containing `\k` without a closing `>`, which is a literal `k` per [Annex B](https://tc39.es/ecma262/#sec-regular-expressions-patterns) semantics, and ensured a `\k` not immediately followed by `<` is treated as that literal escape rather than fused with pattern text up to any later `>`
 - Fixed character class scanning outside `v` (unicodeSets) mode to treat `[` as a literal character, ending the class at the first unescaped `]` instead of extending past the class boundary
+- Fixed literal astral plane characters in unicode-aware patterns (`u`/`v` flags) being split into lone-surrogate atoms that could never match, so `README.md`'s stated behaviour of matching whole astral characters now holds for literals as well as `\u{...}` escapes
 
 ### Changed
 

--- a/src/createPartialMatchRegex.test.ts
+++ b/src/createPartialMatchRegex.test.ts
@@ -71,6 +71,33 @@ describe("regexp-partial-match", () => {
         characters: ["a", "́", ..."suffix".split("")]
       });
     });
+
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Literal_character
+    describe("astral plane characters", () => {
+      it("should support partial matching of literal astral plane characters in unicode mode (with caveat that surrogate pairs do not match independently)", () => {
+        const input = /😀suffix/u;
+        const partial = createPartialMatchRegex(input);
+        expect(partial).toMatchPartially({
+          characters: ["😀", ..."suffix".split("")] // "😀".length === 2
+        });
+      });
+
+      it("should support partial matching of literal astral plane characters in unicodeSets mode (with caveat that surrogate pairs do not match independently)", () => {
+        const input = /😀suffix/v;
+        const partial = createPartialMatchRegex(input);
+        expect(partial).toMatchPartially({
+          characters: ["😀", ..."suffix".split("")]
+        });
+      });
+
+      it("should support partial matching of individual surrogate code units of literal astral plane characters, in non-unicode mode", () => {
+        const input = /😀suffix/;
+        const partial = createPartialMatchRegex(input);
+        expect(partial).toMatchPartially({
+          characters: [..."😀".split(""), ..."suffix".split("")]
+        });
+      });
+    });
   });
 
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Wildcard

--- a/src/createPartialMatchRegex.ts
+++ b/src/createPartialMatchRegex.ts
@@ -167,7 +167,9 @@ const createPartialMatchRegex = (regex: RegExp): RegExp => {
           ++i;
           return result;
         default:
-          appendOptional(1);
+          appendOptional(
+            isUnicode && (source.codePointAt(i) ?? 0) > 0xffff ? 2 : 1
+          );
           break;
       }
     }


### PR DESCRIPTION
# Issue

resolves #47

## Details

The transform walks the pattern source one UTF-16 code unit at a time, so a literal astral-plane character (e.g. `😀`, stored as a surrogate pair) was split into two separate optional atoms. In unicode-aware mode (`u`/`v` flags), a lone surrogate can never match half of a paired character in the input, so every matching path failed — even for a complete match:

```javascript
/😀x/u.test("😀x"); // true — original regex works

const partial = createPartialMatchRegex(/😀x/u);
partial.exec("😀x"); // was null, now "😀x" at 0
partial.exec("😀");  // was null, now "😀" at 0
```

The fix sizes the default atom by code point when the pattern is unicode-aware: if `source.codePointAt(i)` exceeds `0xFFFF` the position sits on a high surrogate followed by a low surrogate, and both units are emitted as a single atom. This mirrors the existing handling of `\u{...}` escapes, and brings literals in line with `README.md`'s documented "Surrogate Pair Matching" behaviour (whole astral characters match; individual surrogate halves still do not match independently, per the existing caveat). 

Non-unicode patterns are unchanged — there, per-code-unit atoms are correct, and a new test pins that lone surrogate units continue to match independently.

## Semantic Version Impact

_Select ONE checkbox to indicate the semver impact of this change. Learn more at https://semver.org/. If multiple are selected, **MAJOR** takes precedence over **MINOR**, which takes precedence over **PATCH**._

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## CheckList

- [x] PR starts with [47]
- [x] I have added an entry to the `[Unreleased]` section in `docs/CHANGELOG.md`
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
