### PR TITLE
[55] add test() / exec() documentation back

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ To mitigate, a start anchor (`^`) can prevent the engine from scanning forward t
 > /^(?:x|$)/m.test("a\n") === true; /* '^' matches after '\n' (start of next line) */
 > ```
 
-The [`y` flag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky) prevents matching ahead from the [`lastIndex`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) (defaulting to `0` for a new Regex):
+The [`y` flag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky) prevents matching ahead from the [`lastIndex`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) (defaulting to `0` for a new `RegExp`):
 
 ```js
 /(?:x|$)/y.test("x") === true;

--- a/README.md
+++ b/README.md
@@ -126,12 +126,13 @@ To mitigate, a start anchor (`^`) can prevent the engine from scanning forward t
 /^(?:x|$)/.test("a") === false;
 ```
 
-N.B. The "end of input" match will be the start each line in [multiline mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline):
-
-```js
-/^(?:x|$)/m.test("x") === true;
-/^(?:x|$)/m.test("a\n") === true; /* '^' matches '\n' */
-```
+> [!CAUTION]
+> In [multiline mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline), `^` matches at the start of the string and immediately after each `\n`, so the transformed regex can also match the empty-string `$` alternative on an empty line (including the trailing empty line when the input ends with `\n`):
+>
+> ```js
+> /^(?:x|$)/m.test("x") === true;
+> /^(?:x|$)/m.test("a\n") === true; /* '^' matches after '\n' (start of next line) */
+> ```
 
 The [`y` flag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky) prevents matching ahead from the [`lastIndex`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex):
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The [`y` flag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference
 
 On this basis, `.test()` should be used with caution, and a match of an empty string at the end of the input should instead be considered "no match", if validating that which came before.
 
-i.e.
+e.g.
 
 ```js
 /(?:x|$)/.exec("a"); // ['', index: 1, input: "a", groups: undefined];

--- a/README.md
+++ b/README.md
@@ -106,6 +106,37 @@ The library is compiled to **ES2015** (ECMAScript 6). Certain regular expression
 
 ## Caveats
 
+### [`.test()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) behaviour and non-matching results from [`.exec()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) and [`.match()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match)
+
+The library produces an expression that always matches an empty string, at the end of the input. Feasibly, this is the start of a new partial match.
+
+Hence:
+
+```js
+/x/.test("a") === false; /* untransformed regex */
+/(?:x|$)/.test("a") === true; /* what's produced by the library */
+```
+
+To mitigate, a start boundary anchor can prevent anything _but_ an empty string matching:
+
+```js
+/^(?:x|$)/.test("") === true;
+/^(?:x|$)/.test("x") === true;
+/^(?:x|$)/.test("a") === false;
+```
+
+On this basis, `.test()` should be used with caution, and a match of an empty string at the end of the input should instead be considered "no match", if validating that which came before.
+
+i.e.
+
+```js
+/(?:x|$)/.exec("a"); // ['', index: 1, input: "a", groups: undefined];
+"a".match(/(?:x|$)/); // ['', index: 1, input: "a", groups: undefined];
+```
+
+> [!NOTE]
+> An attempt to achieve a more ergonomic `test()` / `exec()` output [was attempted](https://github.com/TomStrepsil/regex-partial-match/pull/51), but proved a complex problem space.
+
 ### Backreferences
 
 **Backreferences cannot be partially matched because they are atomic.** A backreference like `\1` must match the complete captured text or fail entirely, and cannot be split into individual characters for partial matching like regular atoms can.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ i.e.
 ```
 
 > [!NOTE]
-> An attempt to achieve a more ergonomic `test()` / `exec()` output [was attempted](https://github.com/TomStrepsil/regex-partial-match/pull/51), but proved a complex problem space.
+> An attempt to achieve a more ergonomic `test()` / `exec()` output [was made](https://github.com/TomStrepsil/regex-partial-match/pull/51), but proved a complex problem space.
 
 ### Backreferences
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The library is compiled to **ES2015** (ECMAScript 6). Certain regular expression
 
 ### [`.test()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) behaviour and non-matching results from [`.exec()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) and [`.match()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match)
 
-For unanchored patterns (no `^` and not using the `y` flag), the library produces an expression that always matches an empty string, at the end of the input.  Feasibly, this is the start of a new partial match.
+For unanchored patterns (no `^` and not using the `y` flag), the library produces an expression that always matches an empty string at the end of the input (and, per `$` semantics, also immediately before a trailing line terminator).  Feasibly, this is the start of a new partial match.
 
 Hence:
 

--- a/README.md
+++ b/README.md
@@ -108,21 +108,36 @@ The library is compiled to **ES2015** (ECMAScript 6). Certain regular expression
 
 ### [`.test()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) behaviour and non-matching results from [`.exec()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) and [`.match()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match)
 
-The library produces an expression that always matches an empty string, at the end of the input. Feasibly, this is the start of a new partial match.
+For unanchored patterns (no `^` and not using the `y` flag), the library produces an expression that always matches an empty string, at the end of the input.  Feasibly, this is the start of a new partial match.
 
 Hence:
 
 ```js
 /x/.test("a") === false; /* untransformed regex */
-/(?:x|$)/.test("a") === true; /* what's produced by the library */
+/(?:x|$)/.test("a") === true; /* createPartialMatchRegex(/x/) */
 ```
 
-To mitigate, a start boundary anchor can prevent anything _but_ an empty string matching:
+To mitigate, a start anchor (`^`) can prevent the engine from scanning forward to match the empty-string `$` alternative at the end of the input:
 
 ```js
+/* createPartialMatchRegex(/^x/) → /^(?:x|$)/ */
 /^(?:x|$)/.test("") === true;
 /^(?:x|$)/.test("x") === true;
 /^(?:x|$)/.test("a") === false;
+```
+
+N.B. The "end of input" match will be the start each line in [multiline mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline):
+
+```js
+/^(?:x|$)/m.test("x") === true;
+/^(?:x|$)/m.test("a\n") === true; /* '^' matches '\n' */
+```
+
+The [`y` flag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky) prevents matching ahead from the [`lastIndex`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex):
+
+```js
+/(?:x|$)/y.test("x") === true;
+/(?:x|$)/y.test("a") === false;
 ```
 
 On this basis, `.test()` should be used with caution, and a match of an empty string at the end of the input should instead be considered "no match", if validating that which came before.
@@ -135,7 +150,7 @@ i.e.
 ```
 
 > [!NOTE]
-> An attempt to achieve a more ergonomic `test()` / `exec()` output [was made](https://github.com/TomStrepsil/regex-partial-match/pull/51), but proved a complex problem space.
+> A more ergonomic `test()` / `exec()` output [was explored](https://github.com/TomStrepsil/regex-partial-match/pull/51), but proved a complex problem space.
 
 ### Backreferences
 

--- a/README.md
+++ b/README.md
@@ -134,12 +134,15 @@ To mitigate, a start anchor (`^`) can prevent the engine from scanning forward t
 > /^(?:x|$)/m.test("a\n") === true; /* '^' matches after '\n' (start of next line) */
 > ```
 
-The [`y` flag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky) prevents matching ahead from the [`lastIndex`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex):
+The [`y` flag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky) prevents matching ahead from the [`lastIndex`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) (defaulting to `0` for a new Regex):
 
 ```js
 /(?:x|$)/y.test("x") === true;
 /(?:x|$)/y.test("a") === false;
 ```
+
+> [!CAUTION]
+> See [caveats](#sticky-flag-y) re: resetting `lastIndex` when incrementally matching
 
 On this basis, `.test()` should be used with caution, and a match of an empty string at the end of the input should instead be considered "no match", if validating that which came before.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `README.md` to clarify "How It Works", and consistent spelling of "behaviour" (🇬🇧)
 - Upgraded `actions/checkout` to [v7](https://github.com/actions/checkout/tree/v7)
 - Upgraded `actions/github-script` to [v9](https://github.com/actions/github-script/tree/v9)
+- Updated caveat re: `test()` pointing to the abandoned attempt to mitigate
 
 ### Added
 


### PR DESCRIPTION
# Issue

resolves #55

## Details

Add [`test()`/`exec()` caveat from 0.4.0](https://github.com/TomStrepsil/regex-partial-match/tree/v0.4.0#test-behaviour-and-non-matching-results-from-exec-and-match) back to the documentation, updated with a note pointing to [the attempt to properly mitigate](https://github.com/TomStrepsil/regex-partial-match/pull/51).

## Semantic Version Impact

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## CheckList

- [x] PR starts with [_ISSUE_ID_]
- [x] I have added an entry to the `[Unreleased]` section in `docs/CHANGELOG.md`
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
