### PR TITLE
[57] Fix alternation to end of input for multiline scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,49 +115,50 @@ The library is compiled to **ES2015** (ECMAScript 6). Certain regular expression
 
 ### [`.test()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) behaviour and non-matching results from [`.exec()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) and [`.match()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match)
 
-For unanchored patterns (no `^` and not using the `y` flag), the library produces an expression that always matches an empty string at the end of the input (and, per `$` semantics, also immediately before a trailing line terminator).  Feasibly, this is the start of a new partial match.
+For unanchored patterns (no `^` and not using the `y` flag), the library produces an expression that always matches an empty string at the true end of the input — see [How It Works](#how-it-works). Feasibly, this is the start of a new partial match.
 
 Hence:
 
 ```js
 /x/.test("a") === false; /* untransformed regex */
-/(?:x|$)/.test("a") === true; /* createPartialMatchRegex(/x/) */
+/(?:x|$(?![\s\S]))/.test("a") === true; /* createPartialMatchRegex(/x/) */
 ```
 
-To mitigate, a start anchor (`^`) can prevent the engine from scanning forward to match the empty-string `$` alternative at the end of the input:
+To mitigate, a start anchor (`^`) can prevent the engine from scanning forward to match the empty-string fallback at the end of the input:
 
 ```js
-/* createPartialMatchRegex(/^x/) → /^(?:x|$)/ */
-/^(?:x|$)/.test("") === true;
-/^(?:x|$)/.test("x") === true;
-/^(?:x|$)/.test("a") === false;
+/* createPartialMatchRegex(/^x/) → /^(?:x|$(?![\s\S]))/ */
+/^(?:x|$(?![\s\S]))/.test("") === true;
+/^(?:x|$(?![\s\S]))/.test("x") === true;
+/^(?:x|$(?![\s\S]))/.test("a") === false;
 ```
 
 > [!CAUTION]
-> In [multiline mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline), `^` matches at the start of the string and immediately after each `\n`, so the transformed regex can also match the empty-string `$` alternative on an empty line (including the trailing empty line when the input ends with `\n`):
+> In [multiline mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline), `^` still matches at the start of the string and immediately after each `\n`, so the transformed regex can attempt the empty-string fallback at the start of any line — but, since the fallback requires strict end-of-input, it only succeeds if that line start is *also* genuinely where the input ends:
 >
 > ```js
-> /^(?:x|$)/m.test("x") === true;
-> /^(?:x|$)/m.test("a\n") === true; /* '^' matches after '\n' (start of next line) */
+> /^(?:x|$(?![\s\S]))/m.test("x") === true;
+> /^(?:x|$(?![\s\S]))/m.test("a\n") === true;  /* '^' matches after '\n', and input truly ends there */
+> /^(?:x|$(?![\s\S]))/m.test("a\nb") === false; /* '^' matches after '\n', but "b" remains — not genuine end-of-input */
 > ```
 
 The [`y` flag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky) prevents matching ahead from the [`lastIndex`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) (defaulting to `0` for a new `RegExp`):
 
 ```js
-/(?:x|$)/y.test("x") === true;
-/(?:x|$)/y.test("a") === false;
+/(?:x|$(?![\s\S]))/y.test("x") === true;
+/(?:x|$(?![\s\S]))/y.test("a") === false;
 ```
 
 > [!CAUTION]
 > See [caveats](#sticky-flag-y) re: resetting `lastIndex` when incrementally matching
 
-On this basis, `.test()` should be used with caution, and a match of an empty string at the end of the input should instead be considered "no match", if validating that which came before.
+On this basis, `.test()` should be used with caution, and a match of an empty string at the true end of the input should instead be considered "no match", if validating that which came before.
 
 e.g.
 
 ```js
-/(?:x|$)/.exec("a"); // ['', index: 1, input: "a", groups: undefined];
-"a".match(/(?:x|$)/); // ['', index: 1, input: "a", groups: undefined];
+/(?:x|$(?![\s\S]))/.exec("a"); // ['', index: 1, input: "a", groups: undefined];
+"a".match(/(?:x|$(?![\s\S]))/); // ['', index: 1, input: "a", groups: undefined];
 ```
 
 > [!NOTE]
@@ -167,7 +168,7 @@ e.g.
 
 **Backreferences cannot be partially matched because they are atomic.** A backreference like `\1` must match the complete captured text or fail entirely, and cannot be split into individual characters for partial matching like regular atoms can.
 
-Fixed-length patterns like `/(abc)\1/` could theoretically become `/(?:(a)|$)(?:(b)|$)(?:(c)|$)(?:\1|$)(?:\2|$)(?:\3|$)/` (accepting polluted capture indexes as a side-effect), but this doesn't work for variable-length captures.
+Fixed-length patterns like `/(abc)\1/` could theoretically become `/(?:(a)|$(?![\s\S]))(?:(b)|$(?![\s\S]))(?:(c)|$(?![\s\S]))(?:\1|$(?![\s\S]))(?:\2|$(?![\s\S]))(?:\3|$(?![\s\S]))/` (accepting polluted capture indexes as a side-effect), but this doesn't work for variable-length captures.
 
 In a pattern with no named capturing groups, [Annex B](https://tc39.es/ecma262/#sec-regular-expressions-patterns) tolerates `\k<a>` as the literal characters `k<a>`, but this is still treated as if it were a named backreference and matched atomically — `"k"` and `"k<"` will not partially match. A `\k` not immediately followed by a well-formed `<name>` reference is treated as the literal `k` and partially matches as usual.
 

--- a/README.md
+++ b/README.md
@@ -46,13 +46,20 @@ partial.test("hel"); // true
 
 ## How It Works
 
-The library transforms a regular expression by wrapping each [atomic element](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions#atoms) in a [non-capturing group](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Non-capturing_group) with a [disjunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction) to [end-of-input](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Input_boundary_assertion) (`$`):
+The library transforms a regular expression by wrapping each [atomic element](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions#atoms) in a [non-capturing group](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Non-capturing_group) with a [disjunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction) to with a disjunction to a true-end-of-input sentinel (`$(?![\s\S])`):
 
 ```javascript
-/abc/ → /(?:a|$)(?:b|$)(?:c|$)/
+/abc/ → /(?:a|$(?![\s\S]))(?:b|$(?![\s\S]))(?:c|$(?![\s\S]))/
 ```
 
 This allows the pattern to match prefixes of the original pattern, enabling validation of incomplete input.
+
+> [!NOTE]
+> A bare `$` alone isn't sufficient here: under the `m` (multiline) flag — including one turned on locally via a `(?m:...)` [modifier](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Modifier) — `$` also matches immediately before *any* line terminator, not just the true end of input. That would let a `"\n"` the source pattern never allowed for be silently accepted as if the input had simply run out, e.g. `createPartialMatchRegex(/^foobar/m)` would wrongly accept `"foo\nbaz"`. Appending `(?![\s\S])` narrows the disjunction down to strict end-of-input, regardless of multiline state.
+>
+> See [chromium issue 536420076](https://issues.chromium.org/u/2/issues/536420076) for the underlying V8 bug that requires `$` to precede `(?![\s\S])` rather than using the lookahead alone.
+>
+> A shorter option, `(?-m:$)` — disabling multiline locally so `$` means strict end-of-input on its own — also sidesteps the bug and saves a few bytes per atom. However, modifier groups are new enough that support isn't universal, and feature-detecting them would add a fallback branch our test suite can't exercise honestly, since every engine that can realistically be tested against already supports them.
 
 Since the library accepts only valid regular expressions [^1], this enables the algorithm to make lots of unguarded assumptions about the source of the expression.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ partial.test("hel"); // true
 
 ## How It Works
 
-The library transforms a regular expression by wrapping each [atomic element](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions#atoms) in a [non-capturing group](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Non-capturing_group) with a [disjunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction) to with a disjunction to a true-end-of-input sentinel (`$(?![\s\S])`):
+The library transforms a regular expression by wrapping each [atomic element](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions#atoms) in a [non-capturing group](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Non-capturing_group) with a [disjunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction) to a true-end-of-input sentinel (`$(?![\s\S])`):
 
 ```javascript
 /abc/ → /(?:a|$(?![\s\S]))(?:b|$(?![\s\S]))(?:c|$(?![\s\S]))/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed fatal out-of-memory crash when constructing from patterns containing `\k` without a closing `>`, which is a literal `k` per [Annex B](https://tc39.es/ecma262/#sec-regular-expressions-patterns) semantics, and ensured a `\k` not immediately followed by `<` is treated as that literal escape rather than fused with pattern text up to any later `>`
 - Fixed character class scanning outside `v` (unicodeSets) mode to treat `[` as a literal character, ending the class at the first unescaped `]` instead of extending past the class boundary
 - Fixed literal astral plane characters in unicode-aware patterns (`u`/`v` flags) being split into lone-surrogate atoms that could never match, so `README.md`'s stated behaviour of matching whole astral characters now holds for literals as well as `\u{...}` escapes
-- Move to `|$(?![\\s\\S]))` from `|$)` as the alternation to end of input, to better cater for multiline scenarios
+- Move to `|$(?![\s\S]))` from `|$)` as the alternation to end of input, to better cater for multiline scenarios
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed fatal out-of-memory crash when constructing from patterns containing `\k` without a closing `>`, which is a literal `k` per [Annex B](https://tc39.es/ecma262/#sec-regular-expressions-patterns) semantics, and ensured a `\k` not immediately followed by `<` is treated as that literal escape rather than fused with pattern text up to any later `>`
 - Fixed character class scanning outside `v` (unicodeSets) mode to treat `[` as a literal character, ending the class at the first unescaped `]` instead of extending past the class boundary
 - Fixed literal astral plane characters in unicode-aware patterns (`u`/`v` flags) being split into lone-surrogate atoms that could never match, so `README.md`'s stated behaviour of matching whole astral characters now holds for literals as well as `\u{...}` escapes
-- Move to `|$(?![\\s\\S]))` from `|$)` as the alternation to end of input, to better cater for multiline scenarios
+- Moved to `|$(?![\s\S]))` from `|$)` as the alternation to end-of-input, to better cater for multiline scenarios
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed fatal out-of-memory crash when constructing from patterns containing `\k` without a closing `>`, which is a literal `k` per [Annex B](https://tc39.es/ecma262/#sec-regular-expressions-patterns) semantics, and ensured a `\k` not immediately followed by `<` is treated as that literal escape rather than fused with pattern text up to any later `>`
 - Fixed character class scanning outside `v` (unicodeSets) mode to treat `[` as a literal character, ending the class at the first unescaped `]` instead of extending past the class boundary
 - Fixed literal astral plane characters in unicode-aware patterns (`u`/`v` flags) being split into lone-surrogate atoms that could never match, so `README.md`'s stated behaviour of matching whole astral characters now holds for literals as well as `\u{...}` escapes
+- Move to `|$(?![\\s\\S]))` from `|$)` as the alternation to end of input, to better cater for multiline scenarios
 
 ### Changed
 

--- a/src/createPartialMatchRegex.test.ts
+++ b/src/createPartialMatchRegex.test.ts
@@ -1351,10 +1351,6 @@ c`)
       });
 
       it("should not treat a coincidental line boundary as end-of-input when the pattern has no assertion there", () => {
-        // Regression test: the fallback alternation used to mean "or end-of-input" via a bare `$`,
-        // which inherits the `m` flag from the whole generated regex. That let it match at *any*
-        // line boundary, not just the true end of input, so inserting a "\n" where the pattern
-        // still expected literal characters was wrongly accepted as a valid partial match.
         const partial = createPartialMatchRegex(/^foobar/m);
         expect(partial.exec("foo\nbaz")).toNotMatch();
         expect(partial.exec("foo")).toMatchAt({ match: "foo", index: 0 });

--- a/src/createPartialMatchRegex.test.ts
+++ b/src/createPartialMatchRegex.test.ts
@@ -961,6 +961,13 @@ ix`,
       });
     });
 
+    it("should not treat a coincidental line boundary as end-of-input inside a multiline modifier group, even without a top-level multiline flag", () => {
+      const input = /(?m:^foobar)/;
+      const partial = createPartialMatchRegex(input);
+      expect(partial.exec("foo\nbaz")).toNotMatch();
+      expect(partial.exec("foobar")).toMatchAt({ match: "foobar", index: 0 });
+    });
+
     it("should support partial matching of patterns with multiple modifiers", () => {
       const input = /(?ism:^a.c$)\nsuffix/;
       const partial = createPartialMatchRegex(input);
@@ -1336,42 +1343,55 @@ c`)
       expect(partial.exec("")).toMatchAt({ match: "", index: 0 });
     });
 
-    it("should support a bare end-of-input assertion at a line boundary in multiline mode", () => {
-      const partial = createPartialMatchRegex(/$/m);
-      expect(partial.exec("abc\n")).toMatchAt({ match: "", index: 3 });
-    });
-
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline
-    it("should support partial matching of lines in multiline mode", () => {
-      const input = /^foo$/gm;
-      const partial = createPartialMatchRegex(input);
-      const string = "foo\nfoo";
+    describe("multiline mode", () => {
+      it("should support a bare end-of-input assertion at a line boundary in multiline mode", () => {
+        const partial = createPartialMatchRegex(/$/m);
+        expect(partial.exec("abc\n")).toMatchAt({ match: "", index: 3 });
+      });
 
-      for (let i = 1; i < string.length; i++) {
-        const partialString = string.slice(0, i);
-        const result = partial.exec(partialString);
-        expect(result).toMatchAt({
-          match: partialString.slice(0, 3), // always matches up to "foo", stripping newline, before wrapping to next line
-          index: 0
-        });
-        partial.lastIndex = 0;
-      }
-    });
+      it("should not treat a coincidental line boundary as end-of-input when the pattern has no assertion there", () => {
+        // Regression test: the fallback alternation used to mean "or end-of-input" via a bare `$`,
+        // which inherits the `m` flag from the whole generated regex. That let it match at *any*
+        // line boundary, not just the true end of input, so inserting a "\n" where the pattern
+        // still expected literal characters was wrongly accepted as a valid partial match.
+        const partial = createPartialMatchRegex(/^foobar/m);
+        expect(partial.exec("foo\nbaz")).toNotMatch();
+        expect(partial.exec("foo")).toMatchAt({ match: "foo", index: 0 });
+        expect(partial.exec("foobar")).toMatchAt({ match: "foobar", index: 0 });
+      });
 
-    it("should support partial matching of lines in multiline mode with dotAll flag", () => {
-      const input = /^f.o$/gms;
-      const partial = createPartialMatchRegex(input);
-      const string = "f\no\nf\no";
+      it("should support partial matching of lines in multiline mode", () => {
+        const input = /^foo$/gm;
+        const partial = createPartialMatchRegex(input);
+        const string = "foo\nfoo";
 
-      for (let i = 1; i < string.length; i++) {
-        const partialString = string.slice(0, i);
-        const result = partial.exec(partialString);
-        expect(result).toMatchAt({
-          match: partialString.slice(0, 3), // always matches up to "foo", stripping newline, before wrapping to next line
-          index: 0
-        });
-        partial.lastIndex = 0;
-      }
+        for (let i = 1; i < string.length; i++) {
+          const partialString = string.slice(0, i);
+          const result = partial.exec(partialString);
+          expect(result).toMatchAt({
+            match: partialString.slice(0, 3), // always matches up to "foo", stripping newline, before wrapping to next line
+            index: 0
+          });
+          partial.lastIndex = 0;
+        }
+      });
+
+      it("should support partial matching of lines in multiline mode with dotAll flag", () => {
+        const input = /^f.o$/gms;
+        const partial = createPartialMatchRegex(input);
+        const string = "f\no\nf\no";
+
+        for (let i = 1; i < string.length; i++) {
+          const partialString = string.slice(0, i);
+          const result = partial.exec(partialString);
+          expect(result).toMatchAt({
+            match: partialString.slice(0, 3), // always matches up to "foo", stripping newline, before wrapping to next line
+            index: 0
+          });
+          partial.lastIndex = 0;
+        }
+      });
     });
   });
 
@@ -1625,7 +1645,10 @@ c`)
 
       it("should support \\bthe cat\\b with both complete and partial prefixes (PCRE2 inspired)", () => {
         const partial = createPartialMatchRegex(/\bthe cat\b/);
-        expect(partial.exec("the cat")).toMatchAt({ match: "the cat", index: 0 });
+        expect(partial.exec("the cat")).toMatchAt({
+          match: "the cat",
+          index: 0
+        });
         expect(partial.exec("the ca")).toMatchAt({ match: "the ca", index: 0 });
       });
 

--- a/src/createPartialMatchRegex.ts
+++ b/src/createPartialMatchRegex.ts
@@ -1,5 +1,6 @@
 const occurrencesRegex = /\{\d+,?\d*\}/y;
 const notNumbersRegex = /\D/g;
+const alternationToEndOfInput = "|$(?![\\s\\S]))";
 
 const createPartialMatchRegex = (regex: RegExp): RegExp => {
   const source = regex.source;
@@ -15,7 +16,7 @@ const createPartialMatchRegex = (regex: RegExp): RegExp => {
     let result = "";
 
     function appendOptional(length: number) {
-      result += "(?:" + extractSlice(length) + "|$)";
+      result += "(?:" + extractSlice(length) + alternationToEndOfInput;
     }
 
     function appendRaw(length: number) {
@@ -117,7 +118,7 @@ const createPartialMatchRegex = (regex: RegExp): RegExp => {
               case ":":
                 result += "(?:";
                 i += 3;
-                result += process() + "|$)";
+                result += process() + alternationToEndOfInput;
                 break;
               case "=":
                 result += "(?=";
@@ -153,14 +154,14 @@ const createPartialMatchRegex = (regex: RegExp): RegExp => {
                   }
                   default:
                     appendRaw(source.indexOf(">", i) - i + 1);
-                    result += process() + "|$)";
+                    result += process() + alternationToEndOfInput;
                     break;
                 }
                 break;
             }
           } else {
             appendRaw(1);
-            result += process() + "|$)";
+            result += process() + alternationToEndOfInput;
           }
           break;
         case ")":


### PR DESCRIPTION
# Issue

resolves #57

## Details

`createPartialMatchRegex` wrapped every atom in `(?:atom|$)`, using a bare `$` as the "or end-of-input" fallback. Since `$` inherits the `m` flag of the whole generated regex — including when `m` is only turned on locally via a `(?m:...)` modifier group — it also matches immediately before *any* line terminator, not just true end-of-input. That let the transformed regex silently accept a `"\n"` the source pattern never allowed for, producing false-positive partial matches on multiline patterns (e.g. `createPartialMatchRegex(/^foobar/m).test("foo\nbaz")` wrongly returned `true`).

Changed the fallback from `|$)` to `|$(?![\s\S]))`, so it only succeeds at strict end-of-input regardless of multiline state (top-level or scoped via a modifier group). The leading `$` is kept ahead of the lookahead rather than dropped (which would be logically equivalent) to work around a V8 engine bug — see [chromium issue 536420076](https://issues.chromium.org/u/2/issues/536420076) — where a bare `[\s\S]`-based lookahead used as a fallback alternative after a failed multi-code-unit class match misreports the resulting match position on astral-character input.

Also considered `(?-m:$)` (shorter, same fix) but didn't adopt it: modifier-group support isn't universal, and feature-detecting it would add a fallback branch our test suite can't honestly exercise, since every engine we can realistically test against already supports modifiers.

## Semantic Version Impact

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## CheckList

- [x] PR starts with [_ISSUE_ID_]
- [x] I have added an entry to the `[Unreleased]` section in `docs/CHANGELOG.md`
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
