### PR TITLE
[NO ISSUE] more documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ In a pattern with no named capturing groups, [Annex B](https://tc39.es/ecma262/#
 
      A shorter option, `(?-m:$)` — disabling multiline locally so `$` means strict end-of-input on its own — also sidesteps the bug and saves a few bytes per atom. However, modifier groups are new enough that support isn't universal, and feature-detecting them would add a fallback branch our test suite can't exercise honestly, since every engine that can realistically be tested against already supports them.
 
-[^2]: 
+[^2]:
      To remain lightweight, no runtime type validation is applied, so non-TypeScript consumers will be reliant on underlying errors thrown if used incorrectly.
 
 ### Positive Lookbehinds

--- a/README.md
+++ b/README.md
@@ -165,13 +165,15 @@ Fixed-length patterns like `/(abc)\1/` could theoretically become `/(?:(a)|$(?![
 
 In a pattern with no named capturing groups, [Annex B](https://tc39.es/ecma262/#sec-regular-expressions-patterns) tolerates `\k<a>` as the literal characters `k<a>`, but this is still treated as if it were a named backreference and matched atomically — `"k"` and `"k<"` will not partially match. A `\k` not immediately followed by a well-formed `<name>` reference is treated as the literal `k` and partially matches as usual.
 
-[^1]: A bare `$` alone isn't sufficient here: under the `m` (multiline) flag — including one turned on locally via a `(?m:...)` [modifier](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Modifier) — `$` also matches immediately before *any* line terminator, not just the true end of input. That would let a `"\n"` the source pattern never allowed for be silently accepted as if the input had simply run out, e.g. `createPartialMatchRegex(/^foobar/m)` would wrongly accept `"foo\nbaz"`. Appending `(?![\s\S])` narrows the disjunction down to strict end-of-input, regardless of multiline state.
+[^1]: 
+     A bare `$` alone isn't sufficient here: under the `m` (multiline) flag — including one turned on locally via a `(?m:...)` [modifier](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Modifier) — `$` also matches immediately before *any* line terminator, not just the true end of input. That would let a `"\n"` the source pattern never allowed for be silently accepted as if the input had simply run out, e.g. `createPartialMatchRegex(/^foobar/m)` would wrongly accept `"foo\nbaz"`. Appending `(?![\s\S])` narrows the disjunction down to strict end-of-input, regardless of multiline state.
 
-See [chromium issue 536420076](https://issues.chromium.org/u/2/issues/536420076) for the underlying V8 bug that requires `$` to precede `(?![\s\S])` rather than using the lookahead alone.
+     See [chromium issue 536420076](https://issues.chromium.org/u/2/issues/536420076) for the underlying V8 bug that requires `$` to precede `(?![\s\S])` rather than using the lookahead alone.
 
-A shorter option, `(?-m:$)` — disabling multiline locally so `$` means strict end-of-input on its own — also sidesteps the bug and saves a few bytes per atom. However, modifier groups are new enough that support isn't universal, and feature-detecting them would add a fallback branch our test suite can't exercise honestly, since every engine that can realistically be tested against already supports them.
+     A shorter option, `(?-m:$)` — disabling multiline locally so `$` means strict end-of-input on its own — also sidesteps the bug and saves a few bytes per atom. However, modifier groups are new enough that support isn't universal, and feature-detecting them would add a fallback branch our test suite can't exercise honestly, since every engine that can realistically be tested against already supports them.
 
-[^2]: To remain lightweight, no runtime type validation is applied, so non-typescript consumers will be reliant on underlying errors thrown, if used incorrectly.
+[^2]: 
+     To remain lightweight, no runtime type validation is applied, so non-TypeScript consumers will be reliant on underlying errors thrown if used incorrectly.
 
 ### Positive Lookbehinds
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Fixed-length patterns like `/(abc)\1/` could theoretically become `/(?:(a)|$(?![
 
 In a pattern with no named capturing groups, [Annex B](https://tc39.es/ecma262/#sec-regular-expressions-patterns) tolerates `\k<a>` as the literal characters `k<a>`, but this is still treated as if it were a named backreference and matched atomically — `"k"` and `"k<"` will not partially match. A `\k` not immediately followed by a well-formed `<name>` reference is treated as the literal `k` and partially matches as usual.
 
-[^1]: 
+[^1]:
      A bare `$` alone isn't sufficient here: under the `m` (multiline) flag — including one turned on locally via a `(?m:...)` [modifier](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Modifier) — `$` also matches immediately before *any* line terminator, not just the true end of input. That would let a `"\n"` the source pattern never allowed for be silently accepted as if the input had simply run out, e.g. `createPartialMatchRegex(/^foobar/m)` would wrongly accept `"foo\nbaz"`. Appending `(?![\s\S])` narrows the disjunction down to strict end-of-input, regardless of multiline state.
 
      See [chromium issue 536420076](https://issues.chromium.org/u/2/issues/536420076) for the underlying V8 bug that requires `$` to precede `(?![\s\S])` rather than using the lookahead alone.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed fatal out-of-memory crash when constructing from patterns containing `\k` without a closing `>`, which is a literal `k` per [Annex B](https://tc39.es/ecma262/#sec-regular-expressions-patterns) semantics, and ensured a `\k` not immediately followed by `<` is treated as that literal escape rather than fused with pattern text up to any later `>`
 - Fixed character class scanning outside `v` (unicodeSets) mode to treat `[` as a literal character, ending the class at the first unescaped `]` instead of extending past the class boundary
 - Fixed literal astral plane characters in unicode-aware patterns (`u`/`v` flags) being split into lone-surrogate atoms that could never match, so `README.md`'s stated behaviour of matching whole astral characters now holds for literals as well as `\u{...}` escapes
-- Moved to `|$(?![\s\S]))` from `|$)` as the alternation to end-of-input, to better cater for multiline scenarios, added footnote to README to explain
+- Moved to `|$(?![\s\S]))` from `|$)` as the alternation to end-of-input, to better cater for multiline scenarios, and added a README footnote explaining why
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed fatal out-of-memory crash when constructing from patterns containing `\k` without a closing `>`, which is a literal `k` per [Annex B](https://tc39.es/ecma262/#sec-regular-expressions-patterns) semantics, and ensured a `\k` not immediately followed by `<` is treated as that literal escape rather than fused with pattern text up to any later `>`
 - Fixed character class scanning outside `v` (unicodeSets) mode to treat `[` as a literal character, ending the class at the first unescaped `]` instead of extending past the class boundary
 - Fixed literal astral plane characters in unicode-aware patterns (`u`/`v` flags) being split into lone-surrogate atoms that could never match, so `README.md`'s stated behaviour of matching whole astral characters now holds for literals as well as `\u{...}` escapes
-- Moved to `|$(?![\s\S]))` from `|$)` as the alternation to end-of-input, to better cater for multiline scenarios
+- Moved to `|$(?![\s\S]))` from `|$)` as the alternation to end-of-input, to better cater for multiline scenarios, added footnote to README to explain
 
 ### Changed
 

--- a/src/createPartialMatchRegex.test.ts
+++ b/src/createPartialMatchRegex.test.ts
@@ -1382,7 +1382,7 @@ c`)
           const partialString = string.slice(0, i);
           const result = partial.exec(partialString);
           expect(result).toMatchAt({
-            match: partialString.slice(0, 3), // always matches up to "f\no", stripping newline, before wrapping to next line
+            match: partialString.slice(0, 3), // matches a prefix of the first 3 chars ("f\no") without consuming the trailing line terminator
             index: 0
           });
           partial.lastIndex = 0;

--- a/src/createPartialMatchRegex.test.ts
+++ b/src/createPartialMatchRegex.test.ts
@@ -1382,7 +1382,7 @@ c`)
           const partialString = string.slice(0, i);
           const result = partial.exec(partialString);
           expect(result).toMatchAt({
-            match: partialString.slice(0, 3), // matches a prefix of the first 3 chars ("f\no") without consuming the trailing line terminator
+            match: partialString.slice(0, 3), // matches the available prefix up to "f\no" without consuming the following line terminator
             index: 0
           });
           partial.lastIndex = 0;


### PR DESCRIPTION
## Details

- https://github.com/TomStrepsil/regex-partial-match/pull/59 moved details of end-of-input to a footnote, but it was poorly formed, leaving two paragraphs in the main body
- clarity was missing on the comment update on the unit test, from the same PR

## Semantic Version Impact

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## CheckList

- [ ] PR starts with [_ISSUE_ID_]
- [x] I have added an entry to the `[Unreleased]` section in `docs/CHANGELOG.md`
- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
