### PR TITLE
[NO ISSUE] remove named export

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for partial matching of [backreferences](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Backreference) (`\1`, `\k<name>`) — see [docs/backreferences.md](./backreferences.md) for the architecture and the [Backreferences caveat](../README.md#backreferences) for known limitations
 - "benchmarking" workspace, validating `exec()` overhead, with dispatch-overhead, hot-loop (`matchAll` override-check cost), and backreference slow-path scenarios added alongside the original keystroke simulation
 - `types/` folder to fix incorrect types in the standard library 
-- emojis to documentation titles
+- Emojis to documentation titles
 
 ## [0.4.0] - 2026-06-13
 

--- a/src/extend.test.ts
+++ b/src/extend.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { PartialMatchRegExp } from "./partialMatchRegExp.ts";
+import PartialMatchRegExp from "./partialMatchRegExp.ts";
 
 describe("RegExp.prototype.toPartialMatchRegex", () => {
   beforeAll(async () => {

--- a/src/partialMatchRegExp.test.ts
+++ b/src/partialMatchRegExp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { PartialMatchRegExp } from "./partialMatchRegExp.ts";
+import PartialMatchRegExp from "./partialMatchRegExp.ts";
 
 describe("PartialMatchRegExp", () => {
   it("is an instance of RegExp", () => {

--- a/src/partialMatchRegExp.ts
+++ b/src/partialMatchRegExp.ts
@@ -26,7 +26,7 @@ import { compilePartial, type DynamicPath } from "./compilePartial.ts";
  *
  * @see {@link https://github.com/TomStrepsil/regex-partial-match#readme | Documentation}
  */
-export class PartialMatchRegExp extends RegExp {
+class PartialMatchRegExp extends RegExp {
   #static: RegExp | null;
   #dynamic: DynamicPath | null;
 


### PR DESCRIPTION
## Details

The named `{ PartialMatchRegExp }` wasn't intended for the public interface alongside it being a default export, so removed it.

## Semantic Version Impact

This is technically a major change but since the version that introduced `PartialMatchRegExp` is currently unreleased, it's not breaking anyone...

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)
