### PR TITLE
[65] allow dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
   changelog-and-semver-check:
     name: CHANGELOG and Semver Check
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
   changelog-and-semver-check:
     name: CHANGELOG and Semver Check
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,18 +49,28 @@ jobs:
           if [ -z "$LATEST_TAG" ]; then
             echo "No tags found, starting from version 0.0.0"
             LATEST_TAG="v0.0.0"
-            # Get all commits in the repository
-            COMMITS=$(git log --oneline)
+            RANGE=""
           else
             echo "Latest tag: $LATEST_TAG"
-            # Get all commits since the last tag
-            COMMITS=$(git log ${LATEST_TAG}..HEAD --oneline)
+            RANGE="${LATEST_TAG}..HEAD"
           fi
 
+          # Get all commits since the last tag (or all history if no tag)
+          ALL_COMMITS=$(git log $RANGE --oneline)
+
           # Check if there are any commits to process
-          if [ -z "$COMMITS" ]; then
+          if [ -z "$ALL_COMMITS" ]; then
             echo "❌ Error: No commits found since $LATEST_TAG"
             echo "No changes have been made since the last release."
+            exit 1
+          fi
+
+          # Dependabot PRs are exempt from the CHANGELOG/semver checkbox
+          COMMITS=$(git log $RANGE --oneline --perl-regexp --author='^(?!.*dependabot\[bot\])')
+
+          if [ -z "$COMMITS" ]; then
+            echo "❌ Error: Only dependabot commits found since $LATEST_TAG"
+            echo "No user-facing changes have been made since the last release."
             exit 1
           fi
 
@@ -97,7 +107,7 @@ jobs:
               echo "$GH_OUTPUT"
               exit 1
             fi
-            
+
             # Check for semver selections in PR body (look for checked boxes)
             PR_BODY="$GH_OUTPUT"
             if echo "$PR_BODY" | grep -q "\[[xX]\] \*\*MAJOR\*\*"; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,11 +124,23 @@ jobs:
                 MAX_BUMP=1
               fi
             else
-              echo "❌ Error: No version bump checkbox selected in PR #$PR_NUMBER"
-              echo "Please select MAJOR, MINOR, or PATCH in the PR description"
-              exit 1
+              PR_AUTHOR=$(gh pr view "$PR_NUMBER" --json author --jq '.author.login' 2>/dev/null)
+              if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+                echo "Ignoring dependabot PR #$PR_NUMBER (no semver checkbox expected)"
+                continue
+              else
+                echo "❌ Error: No version bump checkbox selected in PR #$PR_NUMBER"
+                echo "Please select MAJOR, MINOR, or PATCH in the PR description"
+                exit 1
+              fi
             fi
           done <<< "$COMMITS"
+
+          if [ "$MAX_BUMP" -eq 0 ]; then
+            echo "❌ Error: Only dependabot commits found since $LATEST_TAG"
+            echo "No user-facing changes have been made since the last release."
+            exit 1
+          fi
 
           # Determine bump type
           case $MAX_BUMP in

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed character class scanning outside `v` (unicodeSets) mode to treat `[` as a literal character, ending the class at the first unescaped `]` instead of extending past the class boundary
 - Fixed literal astral plane characters in unicode-aware patterns (`u`/`v` flags) being split into lone-surrogate atoms that could never match, so `README.md`'s stated behaviour of matching whole astral characters now holds for literals as well as `\u{...}` escapes
 - Moved to `|$(?![\s\S]))` from `|$)` as the alternation to end-of-input, to better cater for multiline scenarios, and added a README footnote explaining why
+- Ensured Dependabot can raise PRs without being blocked by CI
 
 ### Changed
 


### PR DESCRIPTION
# Issue

resolves #65 

## Details

- Allow Dependabot actor to skip the CHANGELOG update in CI.
- Ensure release pipeline doesn't care about Dependabot PRs

## Semantic Version Impact

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## CheckList

- [x] PR starts with [_ISSUE_ID_]
- [x] I have added an entry to the `[Unreleased]` section in `docs/CHANGELOG.md`
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
