### PR TITLE
[67] Export discovered regex features during source walk

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Unlike C/C++ (via [PCRE/PCRE2](https://www.pcre.org/original/doc/html/pcrepartia
 
 This library transforms regular expressions to best-effort support **partial matching**, allowing you to test if an incomplete string could potentially match the full pattern. This is particularly useful for real-time input validation, autocomplete systems, progressive form validation, stream chunk matching, etc.
 
+As a side effect of the parse this requires, each `PartialMatchRegExp` also exposes a [`features`](#partialmatchregexpprototypefeatures-readonlysetregexfeature) set naming the syntactic constructs its pattern uses — useful for consumers that need to reason about a pattern without writing their own regex parser.  For many features, a simple search in the [source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/source) is insufficient.
+
 **Based on an algorithm created by [Lucas Trzesniewski](https://github.com/ltrzesniewski)**, re-created for NPM via ISC license, with permission.
 
 ## 📦 Installation
@@ -54,10 +56,6 @@ The library transforms a regular expression by wrapping each [atomic element](ht
 
 This allows the pattern to match prefixes of the original pattern, enabling validation of incomplete input.
 
-### Patterns with backreferences
-
-Backreferences cannot be handled by the `|$(?![\s\S])` transform alone because they are atomic — `\1` must match the entire captured string or fail, and its length is only known at runtime. `PartialMatchRegExp` first tries a full match natively, as a short-circuit — if the input already satisfies the whole pattern, there's nothing further to do. Otherwise it runs a "capture scan": a variant of the pattern with each backreference swapped for a lazy `(?:[\s\S]*?)` wildcard, so the group it depends on can still capture against a partial input — matching anything, or nothing at all, without needing to already know the backreference's value. Whatever that scan captures (or leaves undefined, if the group hasn't been reached yet) is then used to build a fresh partial-matching regex for this specific input, expanding the backreference character-by-character from the captured value with the same per-atom transform as the rest of the pattern. See [docs/backreferences.md](./docs/backreferences.md) for the full algorithm, including the prefer-longer post-processing that preserves correct captures for groups inside quantifiers.
-
 Since the library accepts only valid regular expressions [^2], this enables the algorithm to make lots of unguarded assumptions about the source of the expression.
 
 The library has been stress-tested with various regular expression features in isolation, and some in likely combination, but obviously it's an unbounded test space, and syntactically valid regular expressions nevertheless support contradictory patterns e.g.
@@ -70,6 +68,13 @@ Such combinations have not been tested.
 
 > [!NOTE]
 > See [Partial Match Parity](/docs/partial-match-parity.md) for full details on how the library compares to reference implementations
+
+### Patterns with backreferences
+
+Backreferences cannot be handled by the `|$(?![\s\S])` transform alone because they are atomic — `\1` must match the entire captured string or fail, and its length is only known at runtime. `PartialMatchRegExp` first tries a full match natively, as a short-circuit — if the input already satisfies the whole pattern, there's nothing further to do. Otherwise it runs a "capture scan": a variant of the pattern with each backreference swapped for a lazy `(?:[\s\S]*?)` wildcard, so the group it depends on can still capture against a partial input — matching anything, or nothing at all, without needing to already know the backreference's value. 
+
+Whatever that scan captures (or leaves `undefined`, if the group hasn't been reached yet) is then used to build a fresh partial-matching regex for this specific input, expanding the backreference character-by-character from the captured value with the same per-atom transform as the rest of the pattern. See [docs/backreferences.md](./docs/backreferences.md) for the full algorithm, including the prefer-longer post-processing that preserves correct captures for groups inside quantifiers.
+
 
 ## ✅ Supported Features
 
@@ -171,17 +176,34 @@ The following cases remain atomic (full native value or exactly at true end of i
 - **`\k<name>` with no named capturing groups in the pattern.** [Annex B](https://tc39.es/ecma262/#sec-regular-expressions-patterns) tolerates this as the literal characters `k<a>`, but it's still treated as if it were a named backreference and matched atomically — `"k"` and `"k<"` will not partially match. A `\k` not immediately followed by a well-formed `<name>` reference is treated as the literal `k` and partially matches as usual.
 - **A backreference whose captured value can't be determined from a partial input.** This only affects the backreference site itself; it's strictly better than rejecting the input outright, and never accepts anything unsound.
 
-See also the [prefix-ambiguous top-level alternation](#prefix-ambiguous-top-level-alternation) caveat below — a related edge case where the internal capture scan resolves the wrong branch first.
+#### Prefix-ambiguous top-level alternation
 
-[^1]:
-     A bare `$` alone isn't sufficient here: under the `m` (multiline) flag — including one turned on locally via a `(?m:...)` [modifier](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Modifier) — `$` also matches immediately before *any* line terminator, not just the true end of input. That would let a `"\n"` the source pattern never allowed for be silently accepted as if the input had simply run out, e.g. `new PartialMatchRegExp(/^foobar/m)` would wrongly accept `"foo\nbaz"`. Appending `(?![\s\S])` narrows the disjunction down to strict end-of-input, regardless of multiline state.
+When a pattern uses top-level alternation where one branch is a strict prefix of another (e.g. `^(ab)\1|^(abc)\2`), the internal capture scan may select the shorter branch — because it uses `(?:[\s\S]*?)` which accepts zero characters — causing the final partial regex to fail for inputs that are valid prefixes of the longer branch. In such cases `exec` returns `null` even though the input is a valid partial match:
 
-     See [chromium issue 536420076](https://issues.chromium.org/u/2/issues/536420076) for the underlying V8 bug that requires `$` to precede `(?![\s\S])` rather than using the lookahead alone.
+```javascript
+const partial = new PartialMatchRegExp(/^(ab)\1|^(abc)\2/);
 
-     A shorter option, `(?-m:$)` — disabling multiline locally so `$` means strict end-of-input on its own — also sidesteps the bug and saves a few bytes per atom. However, modifier groups are new enough that support isn't universal, and feature-detecting them would add a fallback branch our test suite can't exercise honestly, since every engine that can realistically be tested against already supports them.
+partial.test("abca"); // false — but "abca" is a valid prefix of "abcabc" via the second branch
+```
 
-[^2]:
-     To remain lightweight, no runtime type validation is applied, so non-TypeScript consumers will be reliant on underlying errors thrown if used incorrectly.
+> [!TIP]
+> If alternate branches share a prefix, list the longer one first. The capture scan tries branches in order and stops at the first that accepts the partial input, so putting the longer branch first ensures it's the one selected:
+>
+> ```javascript
+> const partial = new PartialMatchRegExp(/^(abc)\2|^(ab)\1/);
+>
+> partial.test("abca"); // true
+> ```
+
+See [docs/backreferences.md](./docs/backreferences.md) for why this happens (the internal capture scan resolving the wrong alternative first).
+
+[^1]: A bare `$` alone isn't sufficient here: under the `m` (multiline) flag — including one turned on locally via a `(?m:...)` [modifier](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Modifier) — `$` also matches immediately before *any* line terminator, not just the true end of input. That would let a `"\n"` the source pattern never allowed for be silently accepted as if the input had simply run out, e.g. `new PartialMatchRegExp(/^foobar/m)` would wrongly accept `"foo\nbaz"`. Appending `(?![\s\S])` narrows the disjunction down to strict end-of-input, regardless of multiline state.
+
+See [chromium issue 536420076](https://issues.chromium.org/u/2/issues/536420076) for the underlying V8 bug that requires `$` to precede `(?![\s\S])` rather than using the lookahead alone.
+
+A shorter option, `(?-m:$)` — disabling multiline locally so `$` means strict end-of-input on its own — also sidesteps the bug and saves a few bytes per atom. However, modifier groups are new enough that support isn't universal, and feature-detecting them would add a fallback branch the test suite can't exercise honestly, since every engine that can realistically be tested against already supports them.
+
+[^2]: To remain lightweight, no runtime type validation is applied, so non-TypeScript consumers will be reliant on underlying errors thrown if used incorrectly.
 
 ### Positive Lookbehinds
 
@@ -237,18 +259,6 @@ As with surrogate pair matching, grapheme clusters / string properties can only 
 Hence, `[\p{RGI_Emoji_Flag_Sequence}]` will match `🇺🇳` as a whole, but not as the individual code points of which it's comprised.
 
 In [`v` mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) expressions, where `[\q{abc}]` syntax is used in isolation (rather than its canonical use-case as a subtraction/intersection of another character class), this will also only match entirely or not at all. i.e. `abc` can match, but not partially.
-
-### Prefix-ambiguous top-level alternation
-
-When a pattern uses top-level alternation where one branch is a strict prefix of another (e.g. `^(ab)\1|^(abc)\2`), the internal capture scan may select the shorter branch — because it uses `(?:[\s\S]*?)` which accepts zero characters — causing the final partial regex to fail for inputs that are valid prefixes of the longer branch. In such cases `exec` returns `null` even though the input is a valid partial match:
-
-```javascript
-const partial = new PartialMatchRegExp(/^(ab)\1|^(abc)\2/);
-
-partial.test("abca"); // false — but "abca" is a valid prefix of "abcabc" via the second branch
-```
-
-See [docs/backreferences.md](./docs/backreferences.md) for why this happens (the internal capture scan resolving the wrong alternative first).
 
 ## 💡 Examples
 
@@ -351,6 +361,63 @@ When using `import 'regex-partial-match/extend'`, this method is added to `RegEx
 **Returns:**
 
 - A new `PartialMatchRegExp` that matches partial strings, created from the `RegExp` instance the method was called on.
+
+### `PartialMatchRegExp.prototype.features: ReadonlySet<RegexFeature>`
+
+Building the partial-match regex requires walking the entire source pattern once. As a side effect of that same walk, each instance records which syntactic constructs its pattern actually uses, exposed as a `features` set — no separate scan of the source is performed to produce it.
+
+This is useful for consumers building on top of `PartialMatchRegExp` who need to reason about which constructs a *specific* pattern uses, without writing their own regex parser to find out. Two concrete cases:
+
+- **Flagging patterns likely to hit one of the [caveats](#caveats) documented above.** For example, a pattern combining `backreference` with `lookbehind`, `negativeLookahead`, or `negativeLookbehind` is a candidate for the [atomic-backreference caveat](#backreferences); one combining `backreference` with `disjunction` is a candidate for the [prefix-ambiguous top-level alternation caveat](#prefix-ambiguous-top-level-alternation). A consumer accepting user-supplied patterns can surface a warning instead of letting the edge case surprise someone later.
+- **Restricting which constructs a product surface allows.** e.g. a system that only wants to accept "simple" patterns (no lookaround, no backreferences) from untrusted input can check `features` against an allow-list and reject the rest, without needing to hand-roll that check against the raw pattern source.
+
+```javascript
+import PartialMatchRegExp from "regex-partial-match";
+
+const partial = new PartialMatchRegExp(/^[a-z]+(?<domain>\.[a-z]+)\1/);
+
+partial.features; // Set { "startAnchor", "characterClass", "quantifier", "namedGroup", "capturingGroup", "backreference" }
+partial.features.has("backreference"); // true
+```
+
+`RegexFeature` is a string union, exported alongside `PartialMatchRegExp`:
+
+| Feature                    | Matches                                                | Notes                                                                          |
+| --------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `patternCharacter`          | An ordinary literal character                          |                                                                                 |
+| `startAnchor`                | Top-level `^`                                           |                                                                                 |
+| `endAnchor`                  | Top-level `$`                                           |                                                                                 |
+| `wordBoundary`               | Top-level `\b`                                          |                                                                                 |
+| `nonWordBoundary`            | Top-level `\B`                                          |                                                                                 |
+| `lookahead`                  | `(?=...)`                                               |                                                                                 |
+| `negativeLookahead`          | `(?!...)`                                               |                                                                                 |
+| `lookbehind`                 | `(?<=...)`                                              |                                                                                 |
+| `negativeLookbehind`         | `(?<!...)`                                              |                                                                                 |
+| `backreference`              | `\1`                                                     |                                                                                 |
+| `namedBackreference`         | `\k<name>`                                              |                                                                                 |
+| `namedGroup`                 | `(?<name>...)`                                          | Always accompanied by `capturingGroup` — see below                            |
+| `capturingGroup`             | `(...)`, including named groups                        |                                                                                 |
+| `nonCapturingGroup`          | `(?:...)`                                               |                                                                                 |
+| `modifierGroup`              | `(?ims:...)`                                            |                                                                                 |
+| `modifierGroupWithRemoval`   | `(?ims-ims:...)`                                        | Mutually exclusive with `modifierGroup`                                       |
+| `characterClass`             | `[...]`                                                 |                                                                                 |
+| `nestedCharacterClass`       | `[...[...]...]`                                         | `v` flag only                                                                  |
+| `classIntersection`          | `&&` inside a character class                          | `v` flag only                                                                  |
+| `classSubtraction`           | `--` inside a character class                          | `v` flag only                                                                  |
+| `disjunction`                | `\|`                                                    |                                                                                 |
+| `quantifier`                 | `*`, `+`, `?`, `{n}`, `{n,}`, `{n,m}`                    |                                                                                 |
+| `unicodePropertyEscape`      | `\p{...}`, `\P{...}`                                    | `u`/`v` flag only — otherwise tagged `otherEscape`                            |
+| `characterClassEscape`       | `\d`, `\D`, `\w`, `\W`, `\s`, `\S`                       |                                                                                 |
+| `controlEscape`               | `\f`, `\n`, `\r`, `\t`, `\v`                             |                                                                                 |
+| `controlLetterEscape`        | `\cX`                                                   |                                                                                 |
+| `hexEscapeSequence`          | `\xXX`                                                  |                                                                                 |
+| `unicodeEscapeSequence`      | `\uXXXX`, `\u{...}`                                     |                                                                                 |
+| `otherEscape`                 | Any other `\X`, e.g. `\.`, `\0`                         |                                                                                 |
+
+Two things worth knowing about how these tags line up with the grammar:
+
+- **One ECMA-262 production can map to several tags.** `Assertion` alone covers `^`, `$`, `\b`, `\B`, and all four lookarounds — `features` splits it by whichever discriminant is easiest to read off during the walk (`^` vs `$`, `=` vs `!` after `(?<`, etc.), since that information is free at the point each construct is recognized.
+- **A named capturing group always carries both `namedGroup` and `capturingGroup`.** The grammar treats a capturing group with a name and one without as the same production (`( GroupSpecifier? Disjunction )`), not two, so both tags are added together.
 
 ## 📜 License
 

--- a/README.md
+++ b/README.md
@@ -197,13 +197,15 @@ partial.test("abca"); // false — but "abca" is a valid prefix of "abcabc" via 
 
 See [docs/backreferences.md](./docs/backreferences.md) for why this happens (the internal capture scan resolving the wrong alternative first).
 
-[^1]: A bare `$` alone isn't sufficient here: under the `m` (multiline) flag — including one turned on locally via a `(?m:...)` [modifier](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Modifier) — `$` also matches immediately before *any* line terminator, not just the true end of input. That would let a `"\n"` the source pattern never allowed for be silently accepted as if the input had simply run out, e.g. `new PartialMatchRegExp(/^foobar/m)` would wrongly accept `"foo\nbaz"`. Appending `(?![\s\S])` narrows the disjunction down to strict end-of-input, regardless of multiline state.
+[^1]: 
+  A bare `$` alone isn't sufficient here: under the `m` (multiline) flag — including one turned on locally via a `(?m:...)` [modifier](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Modifier) — `$` also matches immediately before *any* line terminator, not just the true end of input. That would let a `"\n"` the source pattern never allowed for be silently accepted as if the input had simply run out, e.g. `new PartialMatchRegExp(/^foobar/m)` would wrongly accept `"foo\nbaz"`. Appending `(?![\s\S])` narrows the disjunction down to strict end-of-input, regardless of multiline state.
 
-See [chromium issue 536420076](https://issues.chromium.org/u/2/issues/536420076) for the underlying V8 bug that requires `$` to precede `(?![\s\S])` rather than using the lookahead alone.
+  See [chromium issue 536420076](https://issues.chromium.org/u/2/issues/536420076) for the underlying V8 bug that requires `$` to precede `(?![\s\S])` rather than using the lookahead alone.
 
-A shorter option, `(?-m:$)` — disabling multiline locally so `$` means strict end-of-input on its own — also sidesteps the bug and saves a few bytes per atom. However, modifier groups are new enough that support isn't universal, and feature-detecting them would add a fallback branch the test suite can't exercise honestly, since every engine that can realistically be tested against already supports them.
+  A shorter option, `(?-m:$)` — disabling multiline locally so `$` means strict end-of-input on its own — also sidesteps the bug and saves a few bytes per atom. However, modifier groups are new enough that support isn't universal, and feature-detecting them would add a fallback branch the test suite can't exercise honestly, since every engine that can realistically be tested against already supports them.
 
-[^2]: To remain lightweight, no runtime type validation is applied, so non-TypeScript consumers will be reliant on underlying errors thrown if used incorrectly.
+[^2]: 
+  To remain lightweight, no runtime type validation is applied, so non-TypeScript consumers will be reliant on underlying errors thrown if used incorrectly.
 
 ### Positive Lookbehinds
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Unlike C/C++ (via [PCRE/PCRE2](https://www.pcre.org/original/doc/html/pcrepartia
 
 This library transforms regular expressions to best-effort support **partial matching**, allowing you to test if an incomplete string could potentially match the full pattern. This is particularly useful for real-time input validation, autocomplete systems, progressive form validation, stream chunk matching, etc.
 
-As a side effect of the parse this requires, each `PartialMatchRegExp` also exposes a [`features`](#partialmatchregexpprototypefeatures-readonlysetregexfeature) set naming the syntactic constructs its pattern uses — useful for consumers that need to reason about a pattern without writing their own regex parser.  For many features, a simple search in the [source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/source) is insufficient.
+As a side effect of the parse this requires, each `PartialMatchRegExp` also exposes a [`features`](#partialmatchregexpprototypefeatures-readonlysetregexfeature) set naming the syntactic constructs its pattern uses — useful for consumers that need to reason about a pattern without writing their own regex parser.  For many features, a simple search in the [source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/source) would be insufficient.
 
 **Based on an algorithm created by [Lucas Trzesniewski](https://github.com/ltrzesniewski)**, re-created for NPM via ISC license, with permission.
 

--- a/README.md
+++ b/README.md
@@ -198,14 +198,14 @@ partial.test("abca"); // false — but "abca" is a valid prefix of "abcabc" via 
 See [docs/backreferences.md](./docs/backreferences.md) for why this happens (the internal capture scan resolving the wrong alternative first).
 
 [^1]: 
-  A bare `$` alone isn't sufficient here: under the `m` (multiline) flag — including one turned on locally via a `(?m:...)` [modifier](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Modifier) — `$` also matches immediately before *any* line terminator, not just the true end of input. That would let a `"\n"` the source pattern never allowed for be silently accepted as if the input had simply run out, e.g. `new PartialMatchRegExp(/^foobar/m)` would wrongly accept `"foo\nbaz"`. Appending `(?![\s\S])` narrows the disjunction down to strict end-of-input, regardless of multiline state.
+    A bare `$` alone isn't sufficient here: under the `m` (multiline) flag — including one turned on locally via a `(?m:...)` [modifier](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Modifier) — `$` also matches immediately before *any* line terminator, not just the true end of input. That would let a `"\n"` the source pattern never allowed for be silently accepted as if the input had simply run out, e.g. `new PartialMatchRegExp(/^foobar/m)` would wrongly accept `"foo\nbaz"`. Appending `(?![\s\S])` narrows the disjunction down to strict end-of-input, regardless of multiline state.
 
-  See [chromium issue 536420076](https://issues.chromium.org/u/2/issues/536420076) for the underlying V8 bug that requires `$` to precede `(?![\s\S])` rather than using the lookahead alone.
+    See [chromium issue 536420076](https://issues.chromium.org/u/2/issues/536420076) for the underlying V8 bug that requires `$` to precede `(?![\s\S])` rather than using the lookahead alone.
 
-  A shorter option, `(?-m:$)` — disabling multiline locally so `$` means strict end-of-input on its own — also sidesteps the bug and saves a few bytes per atom. However, modifier groups are new enough that support isn't universal, and feature-detecting them would add a fallback branch the test suite can't exercise honestly, since every engine that can realistically be tested against already supports them.
+    A shorter option, `(?-m:$)` — disabling multiline locally so `$` means strict end-of-input on its own — also sidesteps the bug and saves a few bytes per atom. However, modifier groups are new enough that support isn't universal, and feature-detecting them would add a fallback branch the test suite can't exercise honestly, since every engine that can realistically be tested against already supports them.
 
 [^2]: 
-  To remain lightweight, no runtime type validation is applied, so non-TypeScript consumers will be reliant on underlying errors thrown if used incorrectly.
+    To remain lightweight, no runtime type validation is applied, so non-TypeScript consumers will be reliant on underlying errors thrown if used incorrectly.
 
 ### Positive Lookbehinds
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `features: ReadonlySet<RegexFeature>` field of the created `PartialMatchRegExp`, indicating the discovered features found during walk of the regex
+
+### Fixed
+
+- Moved documentation of caveat regarding prefix-ambiguous top-level alternation to its proper location alongside backreferences, since it only applies when they exist
+
 ## [1.0.0] - 2026-07-22
 
 ### Fixed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moved documentation of caveat regarding prefix-ambiguous top-level alternation to its proper location alongside backreferences, since it only applies when they exist
 
+### Removed
+
+- Removed confusing "multi-engine consistency" comparison that differentiates the testing style of RE2 reference implementation from the parity documentation
+
 ## [1.0.0] - 2026-07-22
 
 ### Fixed

--- a/docs/partial-match-parity.md
+++ b/docs/partial-match-parity.md
@@ -63,7 +63,6 @@ RE2 **explicitly excludes backreferences by design**. From `re2.h`: _"backrefere
 | First-match (NFA) vs longest-match (POSIX) semantics | ✅ ECMAScript / NFA first-match — `(a\|aa)\1` on `"aaaa"` yields `m[1]="a"`, not `"aa"` |
 | Capturing groups across anchoring modes              | ✅ Covered — see groups tests                                                           |
 | Backreferences                                       | ✅ Partial matching supported (RE2 excludes them entirely by design)                    |
-| Multi-engine consistency                             | N/A — JS has a single engine per runtime                                                |
 
 ## ☕ OpenJDK (`java.util.regex` — `RegExTest.java`)
 
@@ -106,4 +105,3 @@ The JDK **does** support backreferences, and `RegExTest.java` includes `backRefT
 | hitEnd() / prefix-only match             |           —            |           —           | ✅ (`\=ps` / `\=ph` subject modifiers) |                 ✅                 | ✅ (non-empty exec result) |
 | requireEnd()                             |           —            |           —           |                    —                    |                 ✅                 |       ⚠️ Not exposed       |
 | Backreference partial matching           | ❌ unsupported dialect | ❌ excluded by design |            ⚠️ Not a focus in testdata            | ⚠️ full match only (`backRefTest`) |             ✅             |
-| Multi-engine consistency                 |           —            |          ✅           |                    —                    |                 —                  |            N/A             |

--- a/src/compilePartial.ts
+++ b/src/compilePartial.ts
@@ -2,7 +2,7 @@ import escapeAtom from "./escapeAtom.ts";
 
 const OCCURRENCES_REGEX = /\{\d+,?\d*\}/y;
 const NOT_NUMBERS_REGEX = /\D/g;
-const ALTERNATION_TO_END_OF_INPUT = "|$(?![\\s\\S]))";
+const DISJUNCTION_TO_END_OF_INPUT = "|$(?![\\s\\S]))";
 const MAYBE_HAS_BACKREFERENCE = /\\[1-9]|\\k</;
 
 interface NumericBackreference {
@@ -26,12 +26,46 @@ const isBackreference = (part: Part): part is Backreference =>
 const isNumericBackreference = (part: Part): part is NumericBackreference =>
   isBackreference(part) && typeof part.ref === "number";
 
-function walk(regex: RegExp): { parts: Part[]; groupCount: number } {
+export type RegexFeature =
+  | "patternCharacter"
+  | "startAnchor"
+  | "endAnchor"
+  | "wordBoundary"
+  | "nonWordBoundary"
+  | "lookahead"
+  | "negativeLookahead"
+  | "lookbehind"
+  | "negativeLookbehind"
+  | "backreference"
+  | "namedBackreference"
+  | "namedGroup"
+  | "capturingGroup"
+  | "nonCapturingGroup"
+  | "modifierGroup"
+  | "modifierGroupWithRemoval"
+  | "characterClass"
+  | "nestedCharacterClass"
+  | "classIntersection"
+  | "classSubtraction"
+  | "disjunction"
+  | "quantifier"
+  | "unicodePropertyEscape"
+  | "characterClassEscape"
+  | "controlEscape"
+  | "controlLetterEscape"
+  | "hexEscapeSequence"
+  | "unicodeEscapeSequence"
+  | "otherEscape";
+
+function walk(
+  regex: RegExp
+): { parts: Part[]; groupCount: number; features: Set<RegexFeature> } {
   const source = regex.source;
   const isUnicode = regex.unicode || regex.unicodeSets;
 
   let i = 0;
   let groupCount = 0;
+  const features = new Set<RegexFeature>();
 
   function extractSlice(length: number): string {
     return source.slice(i, (i += length));
@@ -41,7 +75,7 @@ function walk(regex: RegExp): { parts: Part[]; groupCount: number } {
     const result: Part[] = [];
 
     function appendOptional(length: number) {
-      result.push("(?:" + extractSlice(length) + ALTERNATION_TO_END_OF_INPUT);
+      result.push("(?:" + extractSlice(length) + DISJUNCTION_TO_END_OF_INPUT);
     }
 
     function appendRaw(length: number) {
@@ -60,6 +94,7 @@ function walk(regex: RegExp): { parts: Part[]; groupCount: number } {
         case "\\":
           switch (source[i + 1]) {
             case "c":
+              features.add("controlLetterEscape");
               appendOptional(3);
               break;
             case "k": {
@@ -68,6 +103,7 @@ function walk(regex: RegExp): { parts: Part[]; groupCount: number } {
               if (referenceEnd === -1) {
                 appendOptional(2);
               } else {
+                features.add("namedBackreference");
                 const start = i;
                 const ref = source.slice(i + 3, referenceEnd);
                 i = referenceEnd + 1;
@@ -76,6 +112,7 @@ function walk(regex: RegExp): { parts: Part[]; groupCount: number } {
               break;
             }
             case "u":
+              features.add("unicodeEscapeSequence");
               if (isUnicode && source[i + 2] === "{") {
                 appendOptional(source.indexOf("}", i) - i + 1);
               } else {
@@ -85,13 +122,31 @@ function walk(regex: RegExp): { parts: Part[]; groupCount: number } {
             case "p":
             case "P":
               if (isUnicode) {
+                features.add("unicodePropertyEscape");
                 appendOptional(source.indexOf("}", i) - i + 1);
               } else {
                 appendOptional(2);
               }
               break;
             case "x":
+              features.add("hexEscapeSequence");
               appendOptional(4);
+              break;
+            case "b":
+              features.add("wordBoundary");
+              appendOptional(2);
+              break;
+            case "B":
+              features.add("nonWordBoundary");
+              appendOptional(2);
+              break;
+            case "f":
+            case "n":
+            case "r":
+            case "t":
+            case "v":
+              features.add("controlEscape");
+              appendOptional(2);
               break;
             case "1":
             case "2":
@@ -102,6 +157,7 @@ function walk(regex: RegExp): { parts: Part[]; groupCount: number } {
             case "7":
             case "8":
             case "9": {
+              features.add("backreference");
               NOT_NUMBERS_REGEX.lastIndex = i + 1;
               const nextNonDigit = NOT_NUMBERS_REGEX.exec(source);
               const start = i;
@@ -111,43 +167,82 @@ function walk(regex: RegExp): { parts: Part[]; groupCount: number } {
               result.push({ ref, start, end });
               break;
             }
+            case "d":
+            case "D":
+            case "w":
+            case "W":
+            case "s":
+            case "S":
+              features.add("characterClassEscape");
+              appendOptional(2);
+              break;
             default:
+              features.add("otherEscape");
               appendOptional(2);
               break;
           }
           break;
         case "[": {
+          features.add("characterClass");
           let depth = 1,
-            j = i + 1;
+            j = i + 1,
+            previousSetOperatorCharacter: string | undefined;
           while (depth) {
-            switch (source[j]) {
+            const character = source[j];
+            switch (character) {
               case "\\":
                 j += 2;
+                previousSetOperatorCharacter = undefined;
                 continue;
               case "[":
-                if (regex.unicodeSets) depth++;
+                if (regex.unicodeSets) {
+                  features.add("nestedCharacterClass");
+                  depth++;
+                }
                 break;
               case "]":
                 depth--;
                 break;
+              case "&":
+                if (regex.unicodeSets && previousSetOperatorCharacter === "&") {
+                  features.add("classIntersection");
+                }
+                break;
+              case "-":
+                if (regex.unicodeSets && previousSetOperatorCharacter === "-") {
+                  features.add("classSubtraction");
+                }
+                break;
             }
+            previousSetOperatorCharacter = character;
             j++;
           }
           appendOptional(j - i);
           break;
         }
-        case "|":
         case "^":
+          features.add("startAnchor");
+          appendRaw(1);
+          break;
+        case "$":
+          features.add("endAnchor");
+          appendRaw(1);
+          break;
+        case "|":
+          features.add("disjunction");
+          appendRaw(1);
+          break;
         case "*":
         case "+":
         case "?":
-        case "$":
+          features.add("quantifier");
           appendRaw(1);
           break;
         case "{": {
           OCCURRENCES_REGEX.lastIndex = i;
           const regExpExecArray = OCCURRENCES_REGEX.exec(source);
           if (regExpExecArray) {
+            features.add("quantifier");
             appendRaw(regExpExecArray[0].length);
           } else {
             appendOptional(1);
@@ -158,11 +253,13 @@ function walk(regex: RegExp): { parts: Part[]; groupCount: number } {
           if (source[i + 1] == "?") {
             switch (source[i + 2]) {
               case ":":
+                features.add("nonCapturingGroup");
                 result.push("(?:");
                 i += 3;
-                result.push(...process(), ALTERNATION_TO_END_OF_INPUT);
+                result.push(...process(), DISJUNCTION_TO_END_OF_INPUT);
                 break;
               case "=":
+                features.add("lookahead");
                 result.push("(?=");
                 i += 3;
                 result.push(...process(), ")");
@@ -173,38 +270,53 @@ function walk(regex: RegExp): { parts: Part[]; groupCount: number } {
               case "m": {
                 const flagsStart = i + 2,
                   colonIndex = source.indexOf(":", flagsStart);
-                result.push("(?" + source.slice(flagsStart, colonIndex) + ":");
+                const modifiers = source.slice(flagsStart, colonIndex);
+                features.add(
+                  modifiers.includes("-")
+                    ? "modifierGroupWithRemoval"
+                    : "modifierGroup"
+                );
+                result.push("(?" + modifiers + ":");
                 i = colonIndex + 1;
                 result.push(...process(), ")");
                 break;
               }
               case "!":
+                features.add("negativeLookahead");
                 appendRawGroup(3);
                 break;
               case "<":
                 switch (source[i + 3]) {
                   case "=":
+                    features.add("lookbehind");
+                    appendRawGroup(4);
+                    break;
                   case "!":
+                    features.add("negativeLookbehind");
                     appendRawGroup(4);
                     break;
                   default:
+                    features.add("namedGroup");
+                    features.add("capturingGroup");
                     ++groupCount;
                     appendRaw(source.indexOf(">", i) - i + 1);
-                    result.push(...process(), ALTERNATION_TO_END_OF_INPUT);
+                    result.push(...process(), DISJUNCTION_TO_END_OF_INPUT);
                     break;
                 }
                 break;
             }
           } else {
+            features.add("capturingGroup");
             ++groupCount;
             appendRaw(1);
-            result.push(...process(), ALTERNATION_TO_END_OF_INPUT);
+            result.push(...process(), DISJUNCTION_TO_END_OF_INPUT );
           }
           break;
         case ")":
           ++i;
           return result;
         default:
+          features.add("patternCharacter");
           appendOptional(
             isUnicode && (source.codePointAt(i) ?? 0) > 0xffff ? 2 : 1
           );
@@ -214,7 +326,7 @@ function walk(regex: RegExp): { parts: Part[]; groupCount: number } {
     return result;
   }
 
-  return { parts: process(), groupCount };
+  return { parts: process(), groupCount, features };
 }
 
 function render(
@@ -239,7 +351,7 @@ function reclassifyOctalEscapes(
 ): Part[] {
   return parts.map((part) =>
     isNumericBackreference(part) && part.ref > groupCount
-      ? "(?:" + source.slice(part.start, part.end) + ALTERNATION_TO_END_OF_INPUT
+      ? "(?:" + source.slice(part.start, part.end) + DISJUNCTION_TO_END_OF_INPUT
       : part
   );
 }
@@ -259,7 +371,7 @@ function spliceOriginalSource(
 
 function expandCaptured(value: string, isUnicode: boolean): string {
   return (isUnicode ? Array.from(value) : value.split(""))
-    .map((atom) => "(?:" + escapeAtom(atom) + ALTERNATION_TO_END_OF_INPUT)
+    .map((atom) => "(?:" + escapeAtom(atom) + DISJUNCTION_TO_END_OF_INPUT)
     .join("");
 }
 
@@ -269,17 +381,19 @@ export interface DynamicPath {
   expand: (capture: RegExpExecArray) => string;
 }
 
-export type CompiledPartial =
+export type CompiledPartial = (
   | { kind: "static"; regex: RegExp }
-  | { kind: "dynamic"; dynamic: DynamicPath };
+  | { kind: "dynamic"; dynamic: DynamicPath }
+) & { features: Set<RegexFeature> };
 
 export const compilePartial = (regex: RegExp): CompiledPartial => {
-  const { parts, groupCount } = walk(regex);
+  const { parts, groupCount, features } = walk(regex);
 
   if (!MAYBE_HAS_BACKREFERENCE.test(regex.source)) {
     return {
       kind: "static",
-      regex: new RegExp(render(parts, backrefToken), regex.flags)
+      regex: new RegExp(render(parts, backrefToken), regex.flags),
+      features
     };
   }
 
@@ -291,12 +405,14 @@ export const compilePartial = (regex: RegExp): CompiledPartial => {
   if (backreferences.length === 0) {
     return {
       kind: "static",
-      regex: new RegExp(render(sanitizedParts, backrefToken), regex.flags)
+      regex: new RegExp(render(sanitizedParts, backrefToken), regex.flags),
+      features
     };
   }
 
   return {
     kind: "dynamic",
+    features,
     dynamic: {
       originalCaptureScan: new RegExp(
         spliceOriginalSource(regex.source, backreferences),
@@ -312,7 +428,7 @@ export const compilePartial = (regex: RegExp): CompiledPartial => {
             ? capture[backref.ref]
             : capture.groups?.[backref.ref];
           return captured === undefined
-            ? "(?:" + backrefToken(backref) + ALTERNATION_TO_END_OF_INPUT
+            ? "(?:" + backrefToken(backref) + DISJUNCTION_TO_END_OF_INPUT
             : expandCaptured(captured, isUnicode);
         })
     }

--- a/src/escapeAtom.test.ts
+++ b/src/escapeAtom.test.ts
@@ -1,11 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import escapeAtom from "./escapeAtom";
 
-// All characters the fallback regex treats as metacharacters
 const METACHARACTERS = [".", "*", "+", "?", "^", "$", "{", "}", "(", ")", "|", "[", "]", "\\"];
 
-// Shared contract: both native and fallback must satisfy these.
-// `escape` is the implementation under test (either the full escapeAtom or an isolated fallback).
 function runContractTests(escape: (s: string) => string): void {
   it("returns an empty string unchanged", () => {
     expect(escape("")).toBe("");
@@ -57,9 +54,6 @@ function runContractTests(escape: (s: string) => string): void {
   });
 }
 
-// The manual fallback implementation, isolated so we can assert its exact output format.
-const fallback = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
 describe("escapeAtom — native RegExp.escape path", () => {
   const nativeEscape = (RegExp as { escape?: (s: string) => string }).escape;
 
@@ -67,8 +61,6 @@ describe("escapeAtom — native RegExp.escape path", () => {
     runContractTests(escapeAtom);
 
     it("delegates to RegExp.escape rather than the fallback", () => {
-      // Both must agree on output; if they differ, native takes precedence.
-      // We verify escapeAtom's output equals the native's output (not the fallback's).
       expect(escapeAtom("a.b*c+d?e^f$g{h}i(j)k|l[m]n\\o")).toBe(
         nativeEscape("a.b*c+d?e^f$g{h}i(j)k|l[m]n\\o")
       );
@@ -122,7 +114,7 @@ describe("escapeAtom — fallback path (RegExp.escape absent)", () => {
       METACHARACTERS.join(""),
     ];
     for (const s of samples) {
-      expect(escapeAtom(s)).toBe(fallback(s));
+      expect(escapeAtom(s)).toBe(s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
     }
   });
 });

--- a/src/partialMatchRegExp.test.ts
+++ b/src/partialMatchRegExp.test.ts
@@ -35,6 +35,304 @@ describe("PartialMatchRegExp", () => {
     expect(new PartialMatchRegExp("abc", "gi").ignoreCase).toBe(true);
   });
 
+  describe("features", () => {
+    it("reports only 'patternCharacter' for a plain literal pattern", () => {
+      expect(new PartialMatchRegExp(/foo/).features).toEqual(
+        new Set(["patternCharacter"])
+      );
+    });
+
+    it("detects a top-level ^ as a start anchor", () => {
+      expect(new PartialMatchRegExp(/^foo/).features).toContain("startAnchor");
+    });
+
+    it("detects a top-level $ as an end anchor", () => {
+      expect(new PartialMatchRegExp(/foo$/).features).toContain("endAnchor");
+    });
+
+    it("does not mistake a character class's ^/$ for an anchor", () => {
+      const features = new PartialMatchRegExp(/[^a$bc]/).features;
+      expect(features).not.toContain("startAnchor");
+      expect(features).not.toContain("endAnchor");
+    });
+
+    it("does not mistake nested v-flag character classes for a closed class", () => {
+      const dollar = new PartialMatchRegExp(/[[a-z]$]/v).features;
+      expect(dollar).not.toContain("endAnchor");
+      const caret = new PartialMatchRegExp(/[[a-z]^]/v).features;
+      expect(caret).not.toContain("startAnchor");
+    });
+
+    it("detects a ^ that isn't at the start of the pattern", () => {
+      expect(new PartialMatchRegExp(/foo^bar/).features).toContain(
+        "startAnchor"
+      );
+    });
+
+    it("detects a $ that isn't at the end of the pattern", () => {
+      expect(new PartialMatchRegExp(/foo$bar/).features).toContain("endAnchor");
+    });
+
+    it("detects a ^ inside an alternation branch, a realistic multiline-style shape", () => {
+      expect(new PartialMatchRegExp(/foo|^bar/).features).toContain(
+        "startAnchor"
+      );
+    });
+
+    it("detects a ^ inside a non-capturing group used as a line-start alternative", () => {
+      expect(new PartialMatchRegExp(/(?:^|\n)ERROR/).features).toContain(
+        "startAnchor"
+      );
+    });
+
+    it("detects a top-level \\b as a word boundary", () => {
+      expect(new PartialMatchRegExp(/\bfoo/).features).toContain(
+        "wordBoundary"
+      );
+    });
+
+    it("detects a top-level \\B as a non-word-boundary", () => {
+      expect(new PartialMatchRegExp(/foo\B/).features).toContain(
+        "nonWordBoundary"
+      );
+    });
+
+    it("does not mistake a [\\b] backspace character class for a word boundary", () => {
+      const features = new PartialMatchRegExp(/[\b]/).features;
+      expect(features).not.toContain("wordBoundary");
+      expect(features).not.toContain("nonWordBoundary");
+    });
+
+    it("detects a positive lookahead", () => {
+      expect(new PartialMatchRegExp(/foo(?=bar)/).features).toContain(
+        "lookahead"
+      );
+    });
+
+    it("detects a negative lookahead", () => {
+      expect(new PartialMatchRegExp(/foo(?!bar)/).features).toContain(
+        "negativeLookahead"
+      );
+    });
+
+    it("does not mistake a positive lookahead for a negative one", () => {
+      expect(new PartialMatchRegExp(/foo(?=bar)/).features).not.toContain(
+        "negativeLookahead"
+      );
+    });
+
+    it("detects a positive lookbehind", () => {
+      expect(new PartialMatchRegExp(/(?<=foo)bar/).features).toContain(
+        "lookbehind"
+      );
+    });
+
+    it("detects a negative lookbehind", () => {
+      expect(new PartialMatchRegExp(/(?<!foo)bar/).features).toContain(
+        "negativeLookbehind"
+      );
+    });
+
+    it("does not mistake a positive lookbehind for a negative one", () => {
+      expect(new PartialMatchRegExp(/(?<=foo)bar/).features).not.toContain(
+        "negativeLookbehind"
+      );
+    });
+
+    it("detects a named capturing group as both namedGroup and capturingGroup", () => {
+      const features = new PartialMatchRegExp(/(?<name>foo)/).features;
+      expect(features).toContain("namedGroup");
+      expect(features).toContain("capturingGroup");
+      expect(features).not.toContain("lookbehind");
+      expect(features).not.toContain("negativeLookbehind");
+    });
+
+    it("detects a plain capturing group, without namedGroup", () => {
+      const features = new PartialMatchRegExp(/(foo)/).features;
+      expect(features).toContain("capturingGroup");
+      expect(features).not.toContain("namedGroup");
+    });
+
+    it("detects a non-capturing group", () => {
+      expect(new PartialMatchRegExp(/(?:foo)/).features).toContain(
+        "nonCapturingGroup"
+      );
+    });
+
+    it("detects an add-only modifier group", () => {
+      expect(new PartialMatchRegExp(/(?i:foo)/).features).toContain(
+        "modifierGroup"
+      );
+    });
+
+    it("detects an add-and-remove modifier group, distinct from add-only", () => {
+      const features = new PartialMatchRegExp(/(?i-s:foo)/).features;
+      expect(features).toContain("modifierGroupWithRemoval");
+      expect(features).not.toContain("modifierGroup");
+    });
+
+    it("detects a remove-only modifier group as add-and-remove", () => {
+      expect(new PartialMatchRegExp(/(?-s:foo)/).features).toContain(
+        "modifierGroupWithRemoval"
+      );
+    });
+
+    it("detects a character class", () => {
+      expect(new PartialMatchRegExp(/[a-z]/).features).toContain(
+        "characterClass"
+      );
+    });
+
+    it("detects a nested character class under the v flag", () => {
+      expect(new PartialMatchRegExp(/[[a-z]$]/v).features).toContain(
+        "nestedCharacterClass"
+      );
+    });
+
+    it("does not report a nested character class without the v flag", () => {
+      expect(new PartialMatchRegExp(/[a-z]/).features).not.toContain(
+        "nestedCharacterClass"
+      );
+    });
+
+    it("detects the && intersection operator under the v flag", () => {
+      expect(
+        new PartialMatchRegExp(/[\p{Lowercase}&&\p{Script=Greek}]/v).features
+      ).toContain("classIntersection");
+    });
+
+    it("detects the -- subtraction operator under the v flag", () => {
+      expect(
+        new PartialMatchRegExp(/[\p{Lowercase}--\p{ASCII}]/v).features
+      ).toContain("classSubtraction");
+    });
+
+    it("does not mistake a plain range's single - for a subtraction operator", () => {
+      expect(new PartialMatchRegExp(/[a-z]/v).features).not.toContain(
+        "classSubtraction"
+      );
+    });
+
+    it("does not mistake an escaped & or - for a set operator", () => {
+      const ampersand = new PartialMatchRegExp(/[\&\&]/v).features;
+      expect(ampersand).not.toContain("classIntersection");
+      const dash = new PartialMatchRegExp(/[\-\-]/v).features;
+      expect(dash).not.toContain("classSubtraction");
+    });
+
+    it("does not report a set operator without the v flag", () => {
+      expect(new PartialMatchRegExp(/[a&&b]/).features).not.toContain(
+        "classIntersection"
+      );
+    });
+
+    it("detects disjunction", () => {
+      expect(new PartialMatchRegExp(/foo|bar/).features).toContain(
+        "disjunction"
+      );
+    });
+
+    it("detects quantifiers, both symbolic and bounded", () => {
+      expect(new PartialMatchRegExp(/a+/).features).toContain("quantifier");
+      expect(new PartialMatchRegExp(/a*/).features).toContain("quantifier");
+      expect(new PartialMatchRegExp(/a{2}/).features).toContain("quantifier");
+      expect(new PartialMatchRegExp(/a{2,}/).features).toContain("quantifier");
+      expect(new PartialMatchRegExp(/a{2,4}/).features).toContain("quantifier");
+    });
+
+    it("does not mistake a literal, unclosed { for a quantifier", () => {
+      expect(new PartialMatchRegExp(/a{/).features).not.toContain("quantifier");
+      expect(new PartialMatchRegExp(/a{2/).features).not.toContain(
+        "quantifier"
+      );
+      expect(new PartialMatchRegExp(/a{2,4/).features).not.toContain(
+        "quantifier"
+      );
+    });
+
+    it("detects a numbered backreference, distinct from a named one", () => {
+      const features = new PartialMatchRegExp(/(a)\1/).features;
+      expect(features).toContain("backreference");
+      expect(features).not.toContain("namedBackreference");
+    });
+
+    it("detects a named backreference, distinct from a numbered one", () => {
+      const features = new PartialMatchRegExp(/(?<a>x)\k<a>/).features;
+      expect(features).toContain("namedBackreference");
+      expect(features).not.toContain("backreference");
+    });
+
+    it("does not mistake an unresolvable \\k for a backreference", () => {
+      const features = new PartialMatchRegExp(/\k/).features;
+      expect(features).not.toContain("backreference");
+      expect(features).not.toContain("namedBackreference");
+    });
+
+    it("detects unicode property escapes under the u/v flags", () => {
+      expect(new PartialMatchRegExp(/\p{Letter}/u).features).toContain(
+        "unicodePropertyEscape"
+      );
+    });
+
+    it("does not mistake \\p for a property escape without the u/v flag", () => {
+      expect(new PartialMatchRegExp(/\p/).features).not.toContain(
+        "unicodePropertyEscape"
+      );
+    });
+
+    it("detects a control letter escape (\\cX), distinct from controlEscape", () => {
+      const features = new PartialMatchRegExp(/\cA/).features;
+      expect(features).toContain("controlLetterEscape");
+      expect(features).not.toContain("controlEscape");
+    });
+
+    it("detects control escapes (\\f\\n\\r\\t\\v), distinct from \\cX", () => {
+      for (const source of ["\\f", "\\n", "\\r", "\\t", "\\v"]) {
+        const features = new PartialMatchRegExp(new RegExp(source)).features;
+        expect(features).toContain("controlEscape");
+        expect(features).not.toContain("controlLetterEscape");
+        expect(features).not.toContain("otherEscape");
+      }
+    });
+
+    it("detects a hex escape sequence", () => {
+      expect(new PartialMatchRegExp(/\x41/).features).toContain(
+        "hexEscapeSequence"
+      );
+    });
+
+    it("detects a unicode escape sequence", () => {
+      const pattern = new RegExp("\\u0041");
+      expect(new PartialMatchRegExp(pattern).features).toContain(
+        "unicodeEscapeSequence"
+      );
+    });
+
+    it("detects character class escapes, distinct from other escapes", () => {
+      for (const source of ["\\d", "\\D", "\\w", "\\W", "\\s", "\\S"]) {
+        const features = new PartialMatchRegExp(new RegExp(source)).features;
+        expect(features).toContain("characterClassEscape");
+        expect(features).not.toContain("otherEscape");
+      }
+    });
+
+    it("detects any other escape as otherEscape", () => {
+      expect(new PartialMatchRegExp(/\./).features).toContain("otherEscape");
+    });
+
+    it("detects a plain literal character", () => {
+      expect(new PartialMatchRegExp(/foo/).features).toContain(
+        "patternCharacter"
+      );
+    });
+
+    it("does not mistake escaped, literal lookaround-shaped text for real syntax", () => {
+      expect(new PartialMatchRegExp(/\(\?!\)/).features).not.toContain(
+        "negativeLookahead"
+      );
+    });
+  });
+
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/flags
   describe("supporting flags", () => {
     it("should preserve the flags of the original regex", () => {
@@ -2201,22 +2499,20 @@ c`)
           1: "abc"
         })
       }
-    ].forEach(
-      ({ name, input, validInputs, invalidInputs = [], expected }) => {
-        it(`should support partial matching of ${name}`, () => {
-          const partial = new PartialMatchRegExp(input);
+    ].forEach(({ name, input, validInputs, invalidInputs = [], expected }) => {
+      it(`should support partial matching of ${name}`, () => {
+        const partial = new PartialMatchRegExp(input);
 
-          for (const str of validInputs) {
-            const result = partial.exec(str);
-            expect(result).toMatchObject(expected(str));
-          }
-          for (const str of invalidInputs) {
-            const result = partial.exec(str);
-            expect(result).not.toMatchObject(expected(str));
-          }
-        });
-      }
-    );
+        for (const str of validInputs) {
+          const result = partial.exec(str);
+          expect(result).toMatchObject(expected(str));
+        }
+        for (const str of invalidInputs) {
+          const result = partial.exec(str);
+          expect(result).not.toMatchObject(expected(str));
+        }
+      });
+    });
 
     describe("ECMA spec: backreference to non-participating capturing group matches nothing", () => {
       it("numeric: partial prefix of branch that leaves group non-participating is accepted", () => {
@@ -2384,7 +2680,11 @@ c`)
       const partial = new PartialMatchRegExp(/^(?<word>xy)\k<word>/);
 
       const match = partial.exec("xyx");
-      expect(match).toMatchObject({ 0: "xyx", 1: "xy", groups: { word: "xy" } });
+      expect(match).toMatchObject({
+        0: "xyx",
+        1: "xy",
+        groups: { word: "xy" }
+      });
     });
 
     it("accepts every prefix of 'xyxy' for a named backreference and rejects nearby non-prefix strings", () => {
@@ -2454,9 +2754,7 @@ c`)
 
     describe("match.indices sync with d flag for a repeated group", () => {
       it("match.indices[i] reflects the same resolved capture as match[i] for a repeated group", () => {
-        const groupedBackrefWithIndices = new PartialMatchRegExp(
-          /^(abc)+\1/d
-        );
+        const groupedBackrefWithIndices = new PartialMatchRegExp(/^(abc)+\1/d);
         const m = groupedBackrefWithIndices.exec("abcab");
         expect(m).toMatchObject({ 1: "abc", indices: { 1: [0, 3] } });
       });

--- a/src/partialMatchRegExp.ts
+++ b/src/partialMatchRegExp.ts
@@ -1,4 +1,10 @@
-import { compilePartial, type DynamicPath } from "./compilePartial.ts";
+import {
+  compilePartial,
+  type DynamicPath,
+  type RegexFeature
+} from "./compilePartial.ts";
+
+export type { RegexFeature };
 
 /**
  * A `RegExp` subclass that supports partial (prefix) matching.
@@ -30,12 +36,15 @@ class PartialMatchRegExp extends RegExp {
   #static: RegExp | null;
   #dynamic: DynamicPath | null;
 
+  readonly features: ReadonlySet<RegexFeature>;
+
   constructor(pattern: RegExp | string, flags?: string) {
     super(pattern, flags);
     const compiled = compilePartial(this);
     [this.#dynamic, this.#static] = compiled.kind === "dynamic"
       ? [compiled.dynamic, null]
       : [null, compiled.regex];
+    this.features = compiled.features;
   }
 
   override exec(input: string): RegExpExecArray | null {


### PR DESCRIPTION
# Issue

resolves #67

## Details

Adds a `features: ReadonlySet<RegexFeature>` property to `PartialMatchRegExp`, populated as a side effect of the walk `compilePartial` already performs to build the partial-match regex. 

`RegexFeature` is a string union naming every distinct syntactic construct the walk recognises (anchors, word boundaries, lookaround forms, backreferences, group forms, `v`-flag class operators, quantifiers, escape forms, etc.), exported alongside `PartialMatchRegExp` for consumers to reference.

README changes:
- New `Overview` note pointing at the fuller `features` write-up.
- New `PartialMatchRegExp.prototype.features` section under `API`, with a table of every `RegexFeature` tag and how the grammar maps to them.
- Relocated the "Prefix-ambiguous top-level alternation" caveat to sit directly after "Backreferences" — it's an artefact of the backreference capture-scan mechanism specifically, not a general alternation concern, so it belongs alongside that section rather than several caveats away.

## Semantic Version Impact

- [ ] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [x] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## Scout rule

- Renamed the internal `ALTERNATION_TO_END_OF_INPUT` constant to `DISJUNCTION_TO_END_OF_INPUT` in `compilePartial.ts` — matches the ECMA-262 grammar term (`|` is a disjunction, not an alternation).
- Removed explanatory comments in `compilePartial.ts`, `partialMatchRegExp.ts`, and `escapeAtom.test.ts` in favour of self-documenting names/structure, with the `features`-related documentation moved into the README instead.
- `docs/partial-match-parity.md`: removed the "Multi-engine consistency" parity-table rows — not applicable to a single-engine (V8/JS) library.

## CheckList

- [x] PR starts with [_ISSUE_ID_]
- [x] I have added an entry to the `[Unreleased]` section in `docs/CHANGELOG.md`
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
