### PR TITLE
[74] E2015 target fix

### DIFF
--- a/.github/scripts/smoke-test-built-package.ts
+++ b/.github/scripts/smoke-test-built-package.ts
@@ -1,0 +1,137 @@
+/**
+ * Verifies the built `lib/` output, in two passes. Called by the CI workflow
+ * after `prepublishOnly`:
+ *
+ *   npm run prepublishOnly && npm run ci:smoke-test-built-package
+ *
+ * First, every emitted file is parsed at the ECMAScript version the README
+ * states the package is compiled to, so syntax newer than that floor fails the
+ * build. Node is far newer than the floor and will happily run output the
+ * stated environment could not, so this is checked statically rather than by
+ * executing under an older engine — no ESM-capable runtime is that old.
+ *
+ * Second, every entry point declared in package.json "exports" is loaded under
+ * both `import` and `require`, and asserted to behave. The unit tests run
+ * against `src/`, so they cannot see defects introduced by the build itself —
+ * v1.1.1 shipped a `lib/` that threw `SyntaxError: 'super' keyword unexpected
+ * here` on load while all 408 tests passed. Specifiers are resolved by name
+ * rather than by path so that Node applies the real "exports" map, exactly as
+ * a consumer would.
+ *
+ * Adding an entry point to "exports" without adding a case to SMOKE_TESTS
+ * fails this script.
+ */
+
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { Linter } from "eslint";
+
+const SUPPORTED_ECMA_VERSION = 2015;
+
+const BUILT_OUTPUT = new URL("../../lib/", import.meta.url);
+
+type LoadedModule = Record<string, unknown>;
+
+type PartialMatchRegExpConstructor = new (
+  pattern: RegExp | string,
+  flags?: string
+) => RegExp;
+
+const SMOKE_TESTS: Record<string, (loaded: LoadedModule) => void> = {
+  ".": (loaded) => {
+    const PartialMatchRegExp =
+      loaded.default as PartialMatchRegExpConstructor | undefined;
+    assert.ok(PartialMatchRegExp, "no default export");
+
+    const partial = new PartialMatchRegExp(/^(\w+) \1 end$/);
+    assert.equal(partial.test("abc ab"), true, "rejects a prefix");
+    assert.equal(partial.test("abc abc end"), true, "rejects a full match");
+    assert.equal(partial.test("abc xyz end"), false, "accepts an impossible input");
+  },
+
+  "./extend": () => {
+    assert.equal(
+      typeof RegExp.prototype.toPartialMatchRegex,
+      "function",
+      "toPartialMatchRegex was not added to RegExp.prototype"
+    );
+    assert.equal(
+      /^hello world$/.toPartialMatchRegex().test("hel"),
+      true,
+      "extended regex rejects a prefix"
+    );
+  }
+};
+
+async function assertBuiltOutputParsesAtSupportedEcmaVersion(): Promise<void> {
+  const linter = new Linter();
+  const entries = await readdir(BUILT_OUTPUT, { recursive: true });
+  const emitted = entries.filter((entry) => entry.endsWith(".js"));
+  assert.ok(
+    emitted.length > 0,
+    "lib/ holds no JavaScript — was prepublishOnly run?"
+  );
+
+  for (const file of emitted) {
+    const source = await readFile(new URL(file, BUILT_OUTPUT), "utf8");
+    const parseError = linter
+      .verify(source, {
+        languageOptions: {
+          ecmaVersion: SUPPORTED_ECMA_VERSION,
+          sourceType: "module"
+        }
+      })
+      .find((message) => message.fatal);
+
+    if (parseError) {
+      assert.fail(
+        `lib/${file} uses syntax newer than ES${String(SUPPORTED_ECMA_VERSION)} — ${parseError.message} (line ${String(parseError.line)})`
+      );
+    }
+    console.log(`  ✓ lib/${file} parses as ES${String(SUPPORTED_ECMA_VERSION)}`);
+  }
+}
+
+async function readExportedSubpaths(): Promise<string[]> {
+  const manifest = await readFile(
+    new URL("../../package.json", import.meta.url),
+    "utf8"
+  );
+  const { exports } = JSON.parse(manifest) as {
+    exports: Record<string, unknown>;
+  };
+  return Object.keys(exports);
+}
+
+function toSpecifier(packageName: string, subpath: string): string {
+  return subpath === "." ? packageName : `${packageName}${subpath.slice(1)}`;
+}
+
+async function main(): Promise<void> {
+  const packageName = "regex-partial-match";
+  const require = createRequire(import.meta.url);
+
+  await assertBuiltOutputParsesAtSupportedEcmaVersion();
+
+  const subpaths = await readExportedSubpaths();
+
+  for (const subpath of subpaths) {
+    const specifier = toSpecifier(packageName, subpath);
+    const smokeTest = SMOKE_TESTS[subpath];
+    assert.ok(
+      smokeTest,
+      `"exports" declares ${subpath} but SMOKE_TESTS has no case for it`
+    );
+
+    smokeTest((await import(specifier)) as LoadedModule);
+    console.log(`  ✓ import("${specifier}")`);
+
+    smokeTest(require(specifier) as LoadedModule);
+    console.log(`  ✓ require("${specifier}")`);
+  }
+
+  console.log(`Smoke tested ${String(subpaths.length)} entry points from lib/`);
+}
+
+await main();

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Run tests
         run: corepack npm test
 
+      - name: Build publishable output
+        run: corepack npm run prepublishOnly
+
+      - name: Smoke test built output
+        run: corepack npm run ci:smoke-test-built-package
+
   changelog-and-semver-check:
     name: CHANGELOG and Semver Check
     runs-on: ubuntu-latest

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the published v[1.1.1](#111---2026-08-02) package failing to load under both `import` and `require` with `SyntaxError: 'super' keyword unexpected here`, caused by the `ES2015` build target moving the `#`-private `#execDynamic()`, and its `super.exec()` call, outside the class body
+
+### Added
+
+- CI now smoke tests the built output, parsing every emitted file at the `ES2015` floor the README states, then loading every `exports` entry point under both `import` and `require`, so defects present only in emitted code are caught before publishing
+
 ## [1.1.1] - 2026-08-02
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "lint:fix": "eslint . --fix",
     "prepare": "simple-git-hooks",
     "prepublishOnly": "tsc -p tsconfig.build.json",
+    "ci:smoke-test-built-package": "node .github/scripts/smoke-test-built-package.ts",
     "test": "vitest run --config ./test/vitest.config.ts",
     "test:watch": "vitest --config ./test/vitest.config.ts"
   },

--- a/src/partialMatchRegExp.ts
+++ b/src/partialMatchRegExp.ts
@@ -47,7 +47,7 @@ class PartialMatchRegExp extends RegExp {
   override exec(input: string): RegExpExecArray | null {
     const compiled = this.#compiledPartial;
     if (compiled.kind === "dynamic")
-      return this.#execDynamic(compiled.dynamic, input);
+      return this._execDynamic(compiled.dynamic, input);
 
     const { regex } = compiled;
     const match = execFrom(regex, input, this.lastIndex);
@@ -55,7 +55,10 @@ class PartialMatchRegExp extends RegExp {
     return match;
   }
 
-  #execDynamic(dynamic: DynamicPath, input: string): RegExpExecArray | null {
+  private _execDynamic(
+    dynamic: DynamicPath,
+    input: string
+  ): RegExpExecArray | null {
     const { originalCaptureScan, preScan, expand } = dynamic;
 
     const honoursLastIndex = this.global || this.sticky;


### PR DESCRIPTION
# Issue

resolves #74

## Details

`regex-partial-match@1.1.1` throws `SyntaxError: 'super' keyword unexpected here` at module load, under both `import` and `require`, making the published package entirely unusable.

The `#`-private `#execDynamic()` extracted in 1.1.1 contains `super.exec(input)`. At the build target of `ES2015`, TypeScript downlevels `#`-private *methods* into standalone functions hoisted outside the class body, where a `super` property access has no `[[HomeObject]]` and is a syntax error. `tsc` emits this without complaint, because the construct is only invalid in the output grammar.

### The fix

The method becomes TypeScript-`private` instead of `#`-private, so it stays in the class body and compiles to a plain prototype method at every target:

```diff
-      return this.#execDynamic(compiled.dynamic, input);
+      return this._execDynamic(compiled.dynamic, input);

-  #execDynamic(dynamic: DynamicPath, input: string): RegExpExecArray | null {
+  private _execDynamic(
+    dynamic: DynamicPath,
+    input: string
+  ): RegExpExecArray | null {
```

The build target stays at `ES2015`. Raising it to `ES2022` would also resolve the syntax error, but it changes the emitted output for every consumer, whereas this keeps the release a pure bug fix.

Trade-off: `private` is a compile-time-only modifier, so `_execDynamic` becomes an enumerable prototype property at runtime rather than being hard-private. It remains inaccessible from TypeScript and is emitted as `private _execDynamic;` in the `.d.ts`, so the public API surface is unchanged.

### Closing the coverage gap

This defect was invisible to the pipeline: `vitest` runs `src/*.ts` directly, `prepublishOnly` runs `tsc` but never loads the output, and nothing in the repo imports `lib/`. The full suite passes against the broken source.

`.github/scripts/smoke-test-built-package.ts` verifies the built `lib/` in two passes.

**Target floor.** Every emitted file is parsed at `ES2015`, the level the README states the package is compiled to. Node is far newer than that floor and will happily run output the stated environment could not, so this is checked statically — no ESM-capable runtime is old enough to execute under ES2015 for real. Parsing uses the `Linter` API from the existing `eslint` devDependency, so this adds no new dependency.

**Entry points.** Every subpath declared in `package.json` `"exports"` is loaded under both `import` and `require`, and asserted to behave. The assertions are deliberately minimal — one backreference pattern, which happens to reach most of the code, and the `RegExp.prototype` augmentation from `./extend`. Depth belongs in the unit tests; this only needs to catch an artefact that does not work at all. Specifiers are resolved by package name via Node's self-reference support, not by file path, so the real `"exports"` map is applied exactly as a consumer would apply it. Subpaths are read from `package.json` rather than hardcoded: adding an entry point without adding a smoke case fails the script.

The parse pass covers syntax, not built-ins — `lib/` could still call a method that does not exist in ES2015 and parse cleanly. The only post-ES2015 built-in the output touches is `RegExp.escape` in `escapeAtom`, which is already feature-detected with `?.` and falls back.

CI's `test` job runs `prepublishOnly` and then the smoke script, after the unit tests. The script is workflow-only, hence the `ci:` prefix on `ci:smoke-test-built-package`.

This deliberately does not re-run the suite against compiled output. The defect class here is "the artefact does not load", which one cheap load per entry point catches; running 349 specs twice buys very little for the runtime and duplication it costs.

### Verification

- On the pre-fix source, `npm test` passes 408/408 while the smoke script exits 1 with `SyntaxError: 'super' keyword unexpected here` at `lib/partialMatchRegExp.js` — the exact production error, caught before publish
- With the fix, `npm test` passes 408/408, all four emitted files parse as ES2015, and all four loads pass from a clean `lib/`
- Building at `--target ES2022` fails the script with `lib/compilePartial.js uses syntax newer than ES2015 — Parsing error: Unexpected token ? (line 258)`
- Adding an unregistered `"exports"` subpath fails the script, as intended
- Builds cleanly at `ES2015` (the build config) and at `ES2022`
- `npm run lint` passes

## Semantic Version Impact

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## CheckList

- [x] PR starts with [_ISSUE_ID_]
- [x] I have added an entry to the `[Unreleased]` section in `docs/CHANGELOG.md`
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
